### PR TITLE
[#2111] improvement(client): cleanup the useless shuffle server clients when unregister shuffle

### DIFF
--- a/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
@@ -1078,8 +1078,7 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
         executorService.shutdownNow();
       }
       shuffleServerInfoMap.remove(appId);
-      ShuffleServerClientFactory.getInstance()
-          .cleanUselessShuffleServerClients(getAllShuffleServers());
+      ShuffleServerClientFactory.getInstance().closeClients(getAllShuffleServers());
     }
   }
 
@@ -1189,8 +1188,7 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
     if (appServerMap != null) {
       Set<ShuffleServerInfo> removed = appServerMap.remove(shuffleId);
       if (removed != null) {
-        ShuffleServerClientFactory.getInstance()
-            .cleanUselessShuffleServerClients(getAllShuffleServers());
+        ShuffleServerClientFactory.getInstance().closeClients(getAllShuffleServers());
       }
     }
   }

--- a/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
@@ -1078,7 +1078,8 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
         executorService.shutdownNow();
       }
       shuffleServerInfoMap.remove(appId);
-      ShuffleServerClientFactory.getInstance().closeClients(getAllShuffleServers());
+      ShuffleServerClientFactory.getInstance()
+          .cleanUselessShuffleServerClients(getAllShuffleServers());
     }
   }
 
@@ -1188,7 +1189,8 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
     if (appServerMap != null) {
       Set<ShuffleServerInfo> removed = appServerMap.remove(shuffleId);
       if (removed != null) {
-        ShuffleServerClientFactory.getInstance().closeClients(getAllShuffleServers());
+        ShuffleServerClientFactory.getInstance()
+            .cleanUselessShuffleServerClients(getAllShuffleServers());
       }
     }
   }

--- a/internal-client/src/main/java/org/apache/uniffle/client/factory/ShuffleServerClientFactory.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/factory/ShuffleServerClientFactory.java
@@ -81,14 +81,14 @@ public class ShuffleServerClientFactory {
   }
 
   public synchronized void cleanUselessShuffleServerClients(
-      Set<ShuffleServerInfo> shuffleServerInfos) {
+      Set<ShuffleServerInfo> usefulShuffleServerInfos) {
     clients
         .values()
         .forEach(
             (serverToClients -> {
               serverToClients.forEach(
                   (shuffleServerInfo, client) -> {
-                    if (!shuffleServerInfos.contains(shuffleServerInfo)) {
+                    if (!usefulShuffleServerInfos.contains(shuffleServerInfo)) {
                       LOG.info("Clean useless shuffle server client for " + shuffleServerInfo);
                       client.close();
                       serverToClients.remove(shuffleServerInfo);

--- a/internal-client/src/main/java/org/apache/uniffle/client/factory/ShuffleServerClientFactory.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/factory/ShuffleServerClientFactory.java
@@ -80,14 +80,15 @@ public class ShuffleServerClientFactory {
     return serverToClients.get(shuffleServerInfo);
   }
 
-  public synchronized void closeClients(Set<ShuffleServerInfo> candidates) {
+  public synchronized void cleanUselessShuffleServerClients(
+      Set<ShuffleServerInfo> usefulShuffleServerInfos) {
     clients
         .values()
         .forEach(
             (serverToClients -> {
               serverToClients.forEach(
                   (shuffleServerInfo, client) -> {
-                    if (!candidates.contains(shuffleServerInfo)) {
+                    if (!usefulShuffleServerInfos.contains(shuffleServerInfo)) {
                       LOG.info("Clean useless shuffle server client for " + shuffleServerInfo);
                       client.close();
                       serverToClients.remove(shuffleServerInfo);

--- a/internal-client/src/main/java/org/apache/uniffle/client/factory/ShuffleServerClientFactory.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/factory/ShuffleServerClientFactory.java
@@ -80,15 +80,14 @@ public class ShuffleServerClientFactory {
     return serverToClients.get(shuffleServerInfo);
   }
 
-  public synchronized void cleanUselessShuffleServerClients(
-      Set<ShuffleServerInfo> usefulShuffleServerInfos) {
+  public synchronized void closeClients(Set<ShuffleServerInfo> candidates) {
     clients
         .values()
         .forEach(
             (serverToClients -> {
               serverToClients.forEach(
                   (shuffleServerInfo, client) -> {
-                    if (!usefulShuffleServerInfos.contains(shuffleServerInfo)) {
+                    if (!candidates.contains(shuffleServerInfo)) {
                       LOG.info("Clean useless shuffle server client for " + shuffleServerInfo);
                       client.close();
                       serverToClients.remove(shuffleServerInfo);

--- a/internal-client/src/test/java/org/apache/uniffle/client/factory/ShuffleServerClientTest.java
+++ b/internal-client/src/test/java/org/apache/uniffle/client/factory/ShuffleServerClientTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.uniffle.client.factory;
+
+import java.util.HashSet;
+import java.util.Map;
+
+import com.google.common.collect.Sets;
+import org.apache.commons.collections4.CollectionUtils;
+import org.junit.jupiter.api.Test;
+
+import org.apache.uniffle.client.api.ShuffleServerClient;
+import org.apache.uniffle.common.ShuffleServerInfo;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ShuffleServerClientTest {
+
+  @Test
+  public void testCleanUselessClient() {
+    ShuffleServerInfo shuffleServerInfo1 = new ShuffleServerInfo("127.0.0.1", 19999);
+    ShuffleServerInfo shuffleServerInfo2 = new ShuffleServerInfo("127.0.0.1", 29999);
+    ShuffleServerInfo shuffleServerInfo3 = new ShuffleServerInfo("127.0.0.1", 39999);
+    String clientType = "grpc_netty";
+    ShuffleServerClientFactory shuffleServerClientFactory =
+        ShuffleServerClientFactory.getInstance();
+    shuffleServerClientFactory.getShuffleServerClient(clientType, shuffleServerInfo1);
+    shuffleServerClientFactory.getShuffleServerClient(clientType, shuffleServerInfo2);
+    shuffleServerClientFactory.getShuffleServerClient(clientType, shuffleServerInfo3);
+    Map<ShuffleServerInfo, ShuffleServerClient> clientMap =
+        shuffleServerClientFactory.getClients().get(clientType);
+    assertEquals(3, clientMap.size());
+    HashSet<ShuffleServerInfo> remainShuffleServers =
+        Sets.newHashSet(shuffleServerInfo1, shuffleServerInfo2);
+    shuffleServerClientFactory.cleanUselessShuffleServerClients(remainShuffleServers);
+    assertEquals(2, clientMap.size());
+    assertTrue(CollectionUtils.isEqualCollection(clientMap.keySet(), remainShuffleServers));
+  }
+}

--- a/internal-client/src/test/java/org/apache/uniffle/client/factory/ShuffleServerClientTest.java
+++ b/internal-client/src/test/java/org/apache/uniffle/client/factory/ShuffleServerClientTest.java
@@ -48,7 +48,7 @@ public class ShuffleServerClientTest {
     assertEquals(3, clientMap.size());
     HashSet<ShuffleServerInfo> remainShuffleServers =
         Sets.newHashSet(shuffleServerInfo1, shuffleServerInfo2);
-    shuffleServerClientFactory.cleanUselessShuffleServerClients(remainShuffleServers);
+    shuffleServerClientFactory.closeClients(remainShuffleServers);
     assertEquals(2, clientMap.size());
     assertTrue(CollectionUtils.isEqualCollection(clientMap.keySet(), remainShuffleServers));
   }

--- a/internal-client/src/test/java/org/apache/uniffle/client/factory/ShuffleServerClientTest.java
+++ b/internal-client/src/test/java/org/apache/uniffle/client/factory/ShuffleServerClientTest.java
@@ -48,7 +48,7 @@ public class ShuffleServerClientTest {
     assertEquals(3, clientMap.size());
     HashSet<ShuffleServerInfo> remainShuffleServers =
         Sets.newHashSet(shuffleServerInfo1, shuffleServerInfo2);
-    shuffleServerClientFactory.closeClients(remainShuffleServers);
+    shuffleServerClientFactory.cleanUselessShuffleServerClients(remainShuffleServers);
     assertEquals(2, clientMap.size());
     assertTrue(CollectionUtils.isEqualCollection(clientMap.keySet(), remainShuffleServers));
   }


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Cleanup useless the shuffle server clients when unregister shuffle

### Why are the changes needed?

Fix: #2111

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

UT