### PR TITLE
[#2383] Improvement: Fix the warning that unchecked call to `RecordsReader(RssConf,SerInputStream,Class<K>,Class<V>,boolean,boolean)` as a member of the raw type `RecordsReader`

### DIFF
--- a/common/src/test/java/org/apache/uniffle/common/merger/MergerTest.java
+++ b/common/src/test/java/org/apache/uniffle/common/merger/MergerTest.java
@@ -41,7 +41,7 @@ import org.apache.uniffle.common.serializer.SerializerUtils;
 import static org.apache.uniffle.common.serializer.SerializerUtils.genData;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class MergerTest {
+class MergerTest {
 
   private static final int RECORDS = 1009;
   private static final int SEGMENTS = 4;
@@ -54,18 +54,18 @@ public class MergerTest {
         "org.apache.hadoop.io.Text,org.apache.hadoop.io.IntWritable,false,true",
         "org.apache.hadoop.io.Text,org.apache.hadoop.io.IntWritable,false,false",
       })
-  public void testMergeSegmentToFile(String classes, @TempDir File tmpDir) throws Exception {
+  void testMergeSegmentToFile(String classes, @TempDir File tmpDir) throws Exception {
     // 1 Parse arguments
     String[] classArray = classes.split(",");
-    Class keyClass = SerializerUtils.getClassByName(classArray[0]);
-    Class valueClass = SerializerUtils.getClassByName(classArray[1]);
-    boolean raw = classArray.length > 2 ? Boolean.parseBoolean(classArray[2]) : false;
-    boolean direct = classArray.length > 3 ? Boolean.parseBoolean(classArray[3]) : false;
+    Class<?> keyClass = SerializerUtils.getClassByName(classArray[0]);
+    Class<?> valueClass = SerializerUtils.getClassByName(classArray[1]);
+    boolean raw = classArray.length > 2 && Boolean.parseBoolean(classArray[2]);
+    boolean direct = classArray.length > 3 && Boolean.parseBoolean(classArray[3]);
 
     // 2 Construct segments, then merge
     RssConf rssConf = new RssConf();
     List<Segment> segments = new ArrayList<>();
-    Comparator comparator = SerializerUtils.getComparator(keyClass);
+    Comparator<?> comparator = SerializerUtils.getComparator(keyClass);
     for (int i = 0; i < SEGMENTS; i++) {
       Segment segment =
           i % 2 == 0
@@ -82,8 +82,8 @@ public class MergerTest {
 
     // 3 Check the merged
     ByteBuf byteBuf = outputStream.toByteBuf();
-    RecordsReader reader =
-        new RecordsReader(
+    RecordsReader<?, ?> reader =
+        new RecordsReader<>(
             rssConf, SerInputStream.newInputStream(byteBuf), keyClass, valueClass, raw, true);
     reader.init();
     SerializerFactory factory = new SerializerFactory(rssConf);

--- a/server/src/test/java/org/apache/uniffle/server/merge/BlockFlushFileReaderTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/merge/BlockFlushFileReaderTest.java
@@ -68,14 +68,14 @@ public class BlockFlushFileReaderTest {
         "org.apache.hadoop.io.Text,org.apache.hadoop.io.IntWritable,8,false,true",
         "org.apache.hadoop.io.Text,org.apache.hadoop.io.IntWritable,8,false,false",
       })
-  public void writeTestWithMerge(String classes, @TempDir File tmpDir) throws Exception {
+  void writeTestWithMerge(String classes, @TempDir File tmpDir) throws Exception {
     final String[] classArray = classes.split(",");
-    final Class keyClass = SerializerUtils.getClassByName(classArray[0]);
-    final Class valueClass = SerializerUtils.getClassByName(classArray[1]);
+    final Class<?> keyClass = SerializerUtils.getClassByName(classArray[0]);
+    final Class<?> valueClass = SerializerUtils.getClassByName(classArray[1]);
     final Comparator comparator = SerializerUtils.getComparator(keyClass);
     final int ringBufferSize = Integer.parseInt(classArray[2]);
-    boolean raw = classArray.length > 3 ? Boolean.parseBoolean(classArray[3]) : false;
-    boolean direct = classArray.length > 4 ? Boolean.parseBoolean(classArray[4]) : false;
+    boolean raw = classArray.length > 3 && Boolean.parseBoolean(classArray[3]);
+    boolean direct = classArray.length > 4 && Boolean.parseBoolean(classArray[4]);
 
     final File dataDir = new File(tmpDir, "data");
     final String[] basePaths = new String[] {dataDir.getAbsolutePath()};
@@ -120,8 +120,8 @@ public class BlockFlushFileReaderTest {
 
     int index = 0;
     ByteBuf byteBuf = outputStream.toByteBuf();
-    RecordsReader reader =
-        new RecordsReader(
+    RecordsReader<?, ?> reader =
+        new RecordsReader<>(
             conf, SerInputStream.newInputStream(byteBuf), keyClass, valueClass, false, false);
     reader.init();
     while (reader.next()) {
@@ -167,15 +167,14 @@ public class BlockFlushFileReaderTest {
         "org.apache.hadoop.io.Text,org.apache.hadoop.io.IntWritable,2,false,true",
         "org.apache.hadoop.io.Text,org.apache.hadoop.io.IntWritable,2,false,false",
       })
-  public void writeTestWithMergeWhenInterrupted(String classes, @TempDir File tmpDir)
-      throws Exception {
+  void writeTestWithMergeWhenInterrupted(String classes, @TempDir File tmpDir) throws Exception {
     String[] classArray = classes.split(",");
-    final Class keyClass = SerializerUtils.getClassByName(classArray[0]);
-    final Class valueClass = SerializerUtils.getClassByName(classArray[1]);
+    final Class<?> keyClass = SerializerUtils.getClassByName(classArray[0]);
+    final Class<?> valueClass = SerializerUtils.getClassByName(classArray[1]);
     final Comparator comparator = SerializerUtils.getComparator(keyClass);
     int ringBufferSize = Integer.parseInt(classArray[2]);
-    boolean raw = classArray.length > 3 ? Boolean.parseBoolean(classArray[3]) : false;
-    boolean direct = classArray.length > 4 ? Boolean.parseBoolean(classArray[4]) : false;
+    boolean raw = classArray.length > 3 && Boolean.parseBoolean(classArray[3]);
+    boolean direct = classArray.length > 4 && Boolean.parseBoolean(classArray[4]);
 
     File dataDir = new File(tmpDir, "data");
     String[] basePaths = new String[] {dataDir.getAbsolutePath()};
@@ -241,8 +240,8 @@ public class BlockFlushFileReaderTest {
         RssConf rssConf,
         SerInputStream inputStream,
         long blockId,
-        Class keyClass,
-        Class valueClass,
+        Class<?> keyClass,
+        Class<?> valueClass,
         long size,
         boolean raw,
         BlockFlushFileReader reader) {

--- a/server/src/test/java/org/apache/uniffle/server/merge/MergedResultTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/merge/MergedResultTest.java
@@ -48,14 +48,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
-public class MergedResultTest {
+class MergedResultTest {
 
   private static final int BYTES_LEN = 10240;
   private static final int RECORDS = 1009;
   private static final int SEGMENTS = 4;
 
   @Test
-  public void testMergedResult() throws IOException {
+  void testMergedResult() throws IOException {
     // 1 Construct cache
     List<Pair<Integer, ByteBuf>> blocks = new ArrayList<>();
     MergedResult.CacheMergedBlockFuntion cache =
@@ -105,13 +105,13 @@ public class MergedResultTest {
         "org.apache.hadoop.io.Text,org.apache.hadoop.io.IntWritable,false,true",
         "org.apache.hadoop.io.Text,org.apache.hadoop.io.IntWritable,false,false",
       })
-  public void testMergeSegmentToMergeResult(String classes, @TempDir File tmpDir) throws Exception {
+  void testMergeSegmentToMergeResult(String classes, @TempDir File tmpDir) throws Exception {
     // 1 Parse arguments
     String[] classArray = classes.split(",");
-    Class keyClass = SerializerUtils.getClassByName(classArray[0]);
-    Class valueClass = SerializerUtils.getClassByName(classArray[1]);
-    boolean raw = classArray.length > 2 ? Boolean.parseBoolean(classArray[2]) : false;
-    boolean direct = classArray.length > 3 ? Boolean.parseBoolean(classArray[3]) : false;
+    Class<?> keyClass = SerializerUtils.getClassByName(classArray[0]);
+    Class<?> valueClass = SerializerUtils.getClassByName(classArray[1]);
+    boolean raw = classArray.length > 2 && Boolean.parseBoolean(classArray[2]);
+    boolean direct = classArray.length > 3 && Boolean.parseBoolean(classArray[3]);
 
     // 2 Construct cache
     List<Pair<Integer, ByteBuf>> blocks = new ArrayList<>();
@@ -151,8 +151,8 @@ public class MergedResultTest {
     assert factory.getSerializer(valueClass).getClass().equals(serializer.getClass());
     SerializerInstance instance = serializer.newInstance();
     for (int i = 0; i < blocks.size(); i++) {
-      RecordsReader reader =
-          new RecordsReader(
+      RecordsReader<?, ?> reader =
+          new RecordsReader<>(
               rssConf,
               SerInputStream.newInputStream(blocks.get(i).getRight()),
               keyClass,

--- a/server/src/test/java/org/apache/uniffle/server/merge/ShuffleMergeManagerTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/merge/ShuffleMergeManagerTest.java
@@ -112,15 +112,15 @@ public class ShuffleMergeManagerTest {
         "org.apache.hadoop.io.Text,org.apache.hadoop.io.IntWritable,false,true",
         "org.apache.hadoop.io.Text,org.apache.hadoop.io.IntWritable,false,false",
       })
-  public void testMergerManager(String classes) throws Exception {
+  void testMergerManager(String classes) throws Exception {
     // 1 Construct serializer and comparator
     final String[] classArray = classes.split(",");
     final String keyClassName = classArray[0];
     final String valueClassName = classArray[1];
-    final Class keyClass = SerializerUtils.getClassByName(keyClassName);
-    final Class valueClass = SerializerUtils.getClassByName(valueClassName);
-    boolean raw = classArray.length > 2 ? Boolean.parseBoolean(classArray[2]) : false;
-    boolean direct = classArray.length > 3 ? Boolean.parseBoolean(classArray[3]) : false;
+    final Class<?> keyClass = SerializerUtils.getClassByName(keyClassName);
+    final Class<?> valueClass = SerializerUtils.getClassByName(valueClassName);
+    boolean raw = classArray.length > 2 && Boolean.parseBoolean(classArray[2]);
+    boolean direct = classArray.length > 3 && Boolean.parseBoolean(classArray[3]);
     final Comparator comparator = SerializerUtils.getComparator(keyClass);
     final String comparatorClassName = comparator.getClass().getName();
     final WritableSerializer serializer = new WritableSerializer(new RssConf());
@@ -218,8 +218,8 @@ public class ShuffleMergeManagerTest {
                 mergeManager.getShuffleData(APP_ID, SHUFFLE_ID, PARTITION_ID, blockId);
             SerInputStream inputStream =
                 SerInputStream.newInputStream(shuffleDataResult.getDataBuf());
-            RecordsReader reader =
-                new RecordsReader(serverConf, inputStream, keyClass, valueClass, raw, true);
+            RecordsReader<?, ?> reader =
+                new RecordsReader<>(serverConf, inputStream, keyClass, valueClass, raw, true);
             reader.init();
             while (reader.next()) {
               if (raw) {
@@ -245,11 +245,10 @@ public class ShuffleMergeManagerTest {
             }
             shuffleDataResult.release();
             blockId++;
-            break;
           } else {
             finish = true;
-            break;
           }
+          break;
         default:
           fail("Find invalid merge state!");
       }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix the warning that unchecked call to `RecordsReader(RssConf,SerInputStream,Class<K>,Class<V>,boolean,boolean)` as a member of the raw type `RecordsReader`

### Why are the changes needed?
Fix: #2383

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
<img width="1113" alt="image" src="https://github.com/user-attachments/assets/5e0dff40-db00-4b68-b67a-319a72093d59" />
