### PR TITLE
[#2385] improvement(test): Make all tests in `integration-common-test` use random port

### DIFF
--- a/integration-test/common/src/test/java/org/apache/uniffle/test/AssignmentWithTagsTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/AssignmentWithTagsTest.java
@@ -18,9 +18,6 @@
 package org.apache.uniffle.test;
 
 import java.io.File;
-import java.io.IOException;
-import java.net.ServerSocket;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -33,8 +30,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import org.apache.uniffle.client.factory.ShuffleClientFactory;
 import org.apache.uniffle.client.impl.ShuffleWriteClientImpl;
@@ -56,29 +51,11 @@ import static org.junit.jupiter.api.Assertions.fail;
  * {@code RssClientConfig.RSS_CLIENT_ASSIGNMENT_TAGS}
  */
 public class AssignmentWithTagsTest extends CoordinatorTestBase {
-  private static final Logger LOG = LoggerFactory.getLogger(AssignmentWithTagsTest.class);
 
   // KV: tag -> shuffle server id
   private static Map<String, List<Integer>> tagOfShufflePorts = new HashMap<>();
   private static final String tag1 = "fixed";
   private static final String tag2 = "elastic";
-
-  private static List<Integer> findAvailablePorts(int num) throws IOException {
-    List<ServerSocket> sockets = new ArrayList<>();
-    List<Integer> ports = new ArrayList<>();
-
-    for (int i = 0; i < num; i++) {
-      ServerSocket socket = new ServerSocket(0);
-      ports.add(socket.getLocalPort());
-      sockets.add(socket);
-    }
-
-    for (ServerSocket socket : sockets) {
-      socket.close();
-    }
-
-    return ports;
-  }
 
   private static void prepareShuffleServerConf(int subDirIndex, Set<String> tags, File tmpDir) {
     ShuffleServerConf shuffleServerConf =

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/CoordinatorAdminServiceTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/CoordinatorAdminServiceTest.java
@@ -34,8 +34,6 @@ import org.apache.uniffle.coordinator.CoordinatorConf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class CoordinatorAdminServiceTest extends IntegrationTestBase {
-
-  private static final Integer JETTY_HTTP_PORT = 12345;
   private static final String accessChecker =
       "org.apache.uniffle.test.AccessClusterTest$MockedAccessChecker";
 
@@ -45,18 +43,16 @@ public class CoordinatorAdminServiceTest extends IntegrationTestBase {
 
   @BeforeAll
   public static void setUp() throws Exception {
-    CoordinatorConf coordinatorConf = new CoordinatorConf();
-    coordinatorConf.set(RssBaseConf.JETTY_HTTP_PORT, JETTY_HTTP_PORT);
+    CoordinatorConf coordinatorConf = coordinatorConfWithoutPort();
     coordinatorConf.set(RssBaseConf.JETTY_CORE_POOL_SIZE, 128);
-    coordinatorConf.set(RssBaseConf.RPC_SERVER_PORT, 12346);
     coordinatorConf.setString(CoordinatorConf.COORDINATOR_ACCESS_CHECKERS.key(), accessChecker);
-    createCoordinatorServer(coordinatorConf);
-    startServers();
+    storeCoordinatorConf(coordinatorConf);
+    startServersWithRandomPorts();
   }
 
   @BeforeEach
   public void createClient() {
-    String hostUrl = String.format("http://%s:%d", LOCALHOST, JETTY_HTTP_PORT);
+    String hostUrl = String.format("http://%s:%d", LOCALHOST, jettyPorts.get(0));
     adminRestApi = new AdminRestApi(UniffleRestClient.builder(hostUrl).build());
   }
 

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/CoordinatorAssignmentTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/CoordinatorAssignmentTest.java
@@ -19,7 +19,6 @@ package org.apache.uniffle.test;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -54,42 +53,34 @@ public class CoordinatorAssignmentTest extends CoordinatorTestBase {
   private static final int SERVER_NUM = 10;
   private static final HashSet<String> TAGS = Sets.newHashSet("t1");
 
-  private static final String QUORUM =
-      LOCALHOST + ":" + COORDINATOR_PORT_1 + "," + LOCALHOST + ":" + COORDINATOR_PORT_2;
-
   @BeforeAll
   public static void setupServers(@TempDir File tmpDir) throws Exception {
-    CoordinatorConf coordinatorConf1 = getCoordinatorConf();
+    CoordinatorConf coordinatorConf1 = coordinatorConfWithoutPort();
     coordinatorConf1.setLong(CoordinatorConf.COORDINATOR_APP_EXPIRED, 2000);
     coordinatorConf1.setInteger(CoordinatorConf.COORDINATOR_SHUFFLE_NODES_MAX, SHUFFLE_NODES_MAX);
     coordinatorConf1.setLong(RssBaseConf.RSS_RECONFIGURE_INTERVAL_SEC, 1L);
-    createCoordinatorServer(coordinatorConf1);
+    storeCoordinatorConf(coordinatorConf1);
 
-    CoordinatorConf coordinatorConf2 = getCoordinatorConf();
+    CoordinatorConf coordinatorConf2 = coordinatorConfWithoutPort();
     coordinatorConf2.setLong(CoordinatorConf.COORDINATOR_APP_EXPIRED, 2000);
     coordinatorConf2.setInteger(CoordinatorConf.COORDINATOR_SHUFFLE_NODES_MAX, SHUFFLE_NODES_MAX);
     coordinatorConf2.setInteger(CoordinatorConf.RPC_SERVER_PORT, COORDINATOR_PORT_2);
     coordinatorConf2.setInteger(CoordinatorConf.JETTY_HTTP_PORT, JETTY_PORT_2);
     coordinatorConf2.setLong(RssBaseConf.RSS_RECONFIGURE_INTERVAL_SEC, 1L);
-    createCoordinatorServer(coordinatorConf2);
+    storeCoordinatorConf(coordinatorConf2);
 
     for (int i = 0; i < SERVER_NUM; i++) {
-      ShuffleServerConf shuffleServerConf = getShuffleServerConf(ServerType.GRPC);
-      File dataDir = new File(tmpDir, "data" + i);
-      String basePath = dataDir.getAbsolutePath();
+      ShuffleServerConf shuffleServerConf =
+          shuffleServerConfWithoutPort(i, tmpDir, ServerType.GRPC);
       shuffleServerConf.setString(
           ShuffleServerConf.RSS_STORAGE_TYPE.key(), StorageType.MEMORY_LOCALFILE_HDFS.name());
-      shuffleServerConf.set(ShuffleServerConf.RSS_STORAGE_BASE_PATH, Arrays.asList(basePath));
       shuffleServerConf.set(RssBaseConf.RPC_METRICS_ENABLED, true);
       shuffleServerConf.set(ShuffleServerConf.SERVER_APP_EXPIRED_WITHOUT_HEARTBEAT, 2000L);
       shuffleServerConf.set(ShuffleServerConf.SERVER_PRE_ALLOCATION_EXPIRED, 5000L);
-      shuffleServerConf.setInteger(RssBaseConf.RPC_SERVER_PORT, 18001 + i);
-      shuffleServerConf.setInteger(RssBaseConf.JETTY_HTTP_PORT, 19010 + i);
       shuffleServerConf.set(ShuffleServerConf.TAGS, new ArrayList<>(TAGS));
-      shuffleServerConf.setString("rss.coordinator.quorum", QUORUM);
-      createShuffleServer(shuffleServerConf);
+      storeShuffleServerConf(shuffleServerConf);
     }
-    startServers();
+    startServersWithRandomPorts();
 
     Thread.sleep(1000 * 5);
   }
@@ -112,7 +103,7 @@ public class CoordinatorAssignmentTest extends CoordinatorTestBase {
             .unregisterTimeSec(10)
             .unregisterRequestTimeSec(10)
             .build();
-    shuffleWriteClient.registerCoordinators(QUORUM);
+    shuffleWriteClient.registerCoordinators(getQuorum());
 
     // Case1: Disable silent period
     ShuffleAssignmentsInfo info =
@@ -154,7 +145,7 @@ public class CoordinatorAssignmentTest extends CoordinatorTestBase {
             .unregisterTimeSec(10)
             .unregisterRequestTimeSec(10)
             .build();
-    shuffleWriteClient.registerCoordinators(COORDINATOR_QUORUM);
+    shuffleWriteClient.registerCoordinators(getQuorum());
 
     /**
      * case1: user specify the illegal shuffle node num(<0) it will use the default shuffle nodes
@@ -204,7 +195,7 @@ public class CoordinatorAssignmentTest extends CoordinatorTestBase {
             .unregisterTimeSec(10)
             .unregisterRequestTimeSec(10)
             .build();
-    shuffleWriteClient.registerCoordinators(COORDINATOR_QUORUM);
+    shuffleWriteClient.registerCoordinators(getQuorum());
     Set<String> excludeServer = Sets.newConcurrentHashSet();
     List<ShuffleServer> excludeShuffleServer =
         grpcShuffleServers.stream().limit(3).collect(Collectors.toList());

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/CoordinatorAssignmentTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/CoordinatorAssignmentTest.java
@@ -64,8 +64,6 @@ public class CoordinatorAssignmentTest extends CoordinatorTestBase {
     CoordinatorConf coordinatorConf2 = coordinatorConfWithoutPort();
     coordinatorConf2.setLong(CoordinatorConf.COORDINATOR_APP_EXPIRED, 2000);
     coordinatorConf2.setInteger(CoordinatorConf.COORDINATOR_SHUFFLE_NODES_MAX, SHUFFLE_NODES_MAX);
-    coordinatorConf2.setInteger(CoordinatorConf.RPC_SERVER_PORT, COORDINATOR_PORT_2);
-    coordinatorConf2.setInteger(CoordinatorConf.JETTY_HTTP_PORT, JETTY_PORT_2);
     coordinatorConf2.setLong(RssBaseConf.RSS_RECONFIGURE_INTERVAL_SEC, 1L);
     storeCoordinatorConf(coordinatorConf2);
 

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/CoordinatorGrpcServerTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/CoordinatorGrpcServerTest.java
@@ -58,7 +58,7 @@ public class CoordinatorGrpcServerTest {
   @Test
   public void testGrpcConnectionSize() throws Exception {
     RssBaseConf baseConf = new RssBaseConf();
-    baseConf.set(RssBaseConf.RPC_SERVER_PORT, 20001);
+    baseConf.set(RssBaseConf.RPC_SERVER_PORT, 0);
     baseConf.set(RssBaseConf.RPC_EXECUTOR_SIZE, 2);
 
     GRPCMetrics grpcMetrics = new CoordinatorGrpcMetrics(baseConf);
@@ -70,7 +70,7 @@ public class CoordinatorGrpcServerTest {
             .addService(new MockedCoordinatorGrpcService())
             .build();
     try {
-      grpcServer.start();
+      final int port = grpcServer.start();
 
       // case1: test the single one connection metric
       double connSize = grpcMetrics.getGaugeMap().get(GRPC_SERVER_CONNECTION_NUMBER_KEY).get();
@@ -78,9 +78,9 @@ public class CoordinatorGrpcServerTest {
 
       // case2: test the multiple connections
       try (CoordinatorGrpcClient coordinatorGrpcClient =
-              new CoordinatorGrpcClient("localhost", 20001);
-          CoordinatorGrpcClient client1 = new CoordinatorGrpcClient("localhost", 20001);
-          CoordinatorGrpcClient client2 = new CoordinatorGrpcClient("localhost", 20001)) {
+              new CoordinatorGrpcClient("localhost", port);
+          CoordinatorGrpcClient client1 = new CoordinatorGrpcClient("localhost", port);
+          CoordinatorGrpcClient client2 = new CoordinatorGrpcClient("localhost", port)) {
         coordinatorGrpcClient.registerApplicationInfo(
             new RssApplicationInfoRequest("testGrpcConnectionSize", 10000, "user"));
 

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/CoordinatorGrpcTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/CoordinatorGrpcTest.java
@@ -17,17 +17,17 @@
 
 package org.apache.uniffle.test;
 
-import java.lang.reflect.Field;
+import java.io.File;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import org.apache.uniffle.client.request.RssApplicationInfoRequest;
 import org.apache.uniffle.client.request.RssGetShuffleAssignmentsRequest;
@@ -38,7 +38,6 @@ import org.apache.uniffle.common.PartitionRange;
 import org.apache.uniffle.common.ShuffleRegisterInfo;
 import org.apache.uniffle.common.ShuffleServerInfo;
 import org.apache.uniffle.common.config.RssBaseConf;
-import org.apache.uniffle.common.config.RssConf;
 import org.apache.uniffle.common.rpc.ServerType;
 import org.apache.uniffle.common.rpc.StatusCode;
 import org.apache.uniffle.common.storage.StorageInfo;
@@ -67,20 +66,18 @@ import static uk.org.webcompere.systemstubs.SystemStubs.withEnvironmentVariables
 public class CoordinatorGrpcTest extends CoordinatorTestBase {
 
   @BeforeAll
-  public static void setupServers() throws Exception {
-    CoordinatorConf coordinatorConf = getCoordinatorConf();
+  public static void setupServers(@TempDir File tmpDir) throws Exception {
+    CoordinatorConf coordinatorConf = coordinatorConfWithoutPort();
     coordinatorConf.set(RssBaseConf.RPC_METRICS_ENABLED, true);
     coordinatorConf.setString(CoordinatorConf.COORDINATOR_ASSIGNMENT_STRATEGY.key(), "BASIC");
     coordinatorConf.setLong("rss.coordinator.app.expired", 2000);
     coordinatorConf.setLong("rss.coordinator.server.heartbeat.timeout", 3000);
-    createCoordinatorServer(coordinatorConf);
-    ShuffleServerConf shuffleServerConf = getShuffleServerConf(ServerType.GRPC);
-    shuffleServerConf.remove(ShuffleServerConf.NETTY_SERVER_PORT.key());
-    createShuffleServer(shuffleServerConf);
-    shuffleServerConf = getShuffleServerConf(ServerType.GRPC);
-    shuffleServerConf.remove(ShuffleServerConf.NETTY_SERVER_PORT.key());
-    createShuffleServer(shuffleServerConf);
-    startServers();
+    storeCoordinatorConf(coordinatorConf);
+
+    storeShuffleServerConf(shuffleServerConfWithoutPort(0, tmpDir, ServerType.GRPC));
+    storeShuffleServerConf(shuffleServerConfWithoutPort(1, tmpDir, ServerType.GRPC));
+
+    startServersWithRandomPorts();
   }
 
   @Test
@@ -141,27 +138,24 @@ public class CoordinatorGrpcTest extends CoordinatorTestBase {
   }
 
   @Test
-  public void getShuffleAssignmentsTest() throws Exception {
+  public void getShuffleAssignmentsTest(@TempDir File tmpDir) throws Exception {
     final String appId = "getShuffleAssignmentsTest";
     CoordinatorTestUtils.waitForRegister(coordinatorClient, 2);
-    // When the shuffleServerHeartbeat Test is completed before the current test,
-    // the server's tags will be [ss_v4, GRPC_NETTY] and [ss_v4, GRPC], respectively.
-    // We need to remove the first machine's tag from GRPC_NETTY to GRPC
-    grpcShuffleServers.get(0).stopServer();
-    RssConf shuffleServerConf = grpcShuffleServers.get(0).getShuffleServerConf();
-    Class<RssConf> clazz = RssConf.class;
-    Field field = clazz.getDeclaredField("settings");
-    field.setAccessible(true);
-    ((ConcurrentHashMap<Object, Object>) field.get(shuffleServerConf))
-        .remove(ShuffleServerConf.NETTY_SERVER_PORT.key());
-    String storageTypeJsonSource = String.format("{\"%s\": \"ssd\"}", baseDir);
 
+    grpcShuffleServers.get(0).stopServer();
+    List<Integer> ports = reserveJettyPorts(1);
+    ShuffleServerConf shuffleServerConf = shuffleServerConfWithoutPort(0, tempDir, ServerType.GRPC);
+    shuffleServerConf.set(ShuffleServerConf.STORAGE_MEDIA_PROVIDER_ENV_KEY, "RSS_ENV_KEY");
+    String baseDir = shuffleServerConf.get(ShuffleServerConf.RSS_STORAGE_BASE_PATH).get(0);
+    shuffleServerConf.setString(ShuffleServerConf.RSS_STORAGE_BASE_PATH.key(), baseDir);
+    String storageTypeJsonSource = String.format("{\"%s\": \"ssd\"}", baseDir);
     withEnvironmentVariables("RSS_ENV_KEY", storageTypeJsonSource)
         .execute(
             () -> {
-              ShuffleServerConf tempShuffleServerConf = getShuffleServerConf(ServerType.GRPC);
-              tempShuffleServerConf.remove(ShuffleServerConf.NETTY_SERVER_PORT.key());
-              ShuffleServer ss = new ShuffleServer(tempShuffleServerConf);
+              shuffleServerConf.setString("rss.coordinator.quorum", getQuorum());
+              shuffleServerConf.setInteger(RssBaseConf.RPC_SERVER_PORT, 0);
+              shuffleServerConf.setInteger(RssBaseConf.JETTY_HTTP_PORT, ports.get(0));
+              ShuffleServer ss = new ShuffleServer(shuffleServerConf);
               ss.start();
               grpcShuffleServers.set(0, ss);
             });
@@ -287,7 +281,7 @@ public class CoordinatorGrpcTest extends CoordinatorTestBase {
   }
 
   @Test
-  public void shuffleServerHeartbeatTest() throws Exception {
+  public void shuffleServerHeartbeatTest(@TempDir File tempDir) throws Exception {
     CoordinatorTestUtils.waitForRegister(coordinatorClient, 2);
     grpcShuffleServers.get(0).stopServer();
     Thread.sleep(5000);
@@ -303,20 +297,25 @@ public class CoordinatorGrpcTest extends CoordinatorTestBase {
     assertEquals(StorageStatus.NORMAL, infoHead.getStatus());
     assertTrue(node.getTags().contains(Constants.SHUFFLE_SERVER_VERSION));
     assertTrue(scm.getTagToNodes().get(Constants.SHUFFLE_SERVER_VERSION).contains(node));
-    ShuffleServerConf shuffleServerConf = getShuffleServerConf(ServerType.GRPC);
+
+    List<Integer> ports = reserveJettyPorts(1);
+    ShuffleServerConf shuffleServerConf = shuffleServerConfWithoutPort(0, tempDir, ServerType.GRPC);
     shuffleServerConf.set(ShuffleServerConf.STORAGE_MEDIA_PROVIDER_ENV_KEY, "RSS_ENV_KEY");
     String baseDir = shuffleServerConf.get(ShuffleServerConf.RSS_STORAGE_BASE_PATH).get(0);
+    shuffleServerConf.setString(ShuffleServerConf.RSS_STORAGE_BASE_PATH.key(), baseDir);
     String storageTypeJsonSource = String.format("{\"%s\": \"ssd\"}", baseDir);
     withEnvironmentVariables("RSS_ENV_KEY", storageTypeJsonSource)
         .execute(
             () -> {
               // set this server's tag to ssd
               shuffleServerConf.set(ShuffleServerConf.TAGS, Lists.newArrayList("SSD"));
+              shuffleServerConf.setString("rss.coordinator.quorum", getQuorum());
+              shuffleServerConf.setInteger(RssBaseConf.RPC_SERVER_PORT, 0);
+              shuffleServerConf.setInteger(RssBaseConf.JETTY_HTTP_PORT, ports.get(0));
               ShuffleServer ss = new ShuffleServer(shuffleServerConf);
               ss.start();
               grpcShuffleServers.set(0, ss);
             });
-    Thread.sleep(3000);
     assertEquals(2, coordinators.get(0).getClusterManager().getNodesNum());
     nodes = scm.getServerList(Sets.newHashSet(Constants.SHUFFLE_SERVER_VERSION, "SSD"));
     assertEquals(1, nodes.size());

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/CoordinatorGrpcTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/CoordinatorGrpcTest.java
@@ -144,7 +144,7 @@ public class CoordinatorGrpcTest extends CoordinatorTestBase {
 
     grpcShuffleServers.get(0).stopServer();
     List<Integer> ports = reserveJettyPorts(1);
-    ShuffleServerConf shuffleServerConf = shuffleServerConfWithoutPort(0, tempDir, ServerType.GRPC);
+    ShuffleServerConf shuffleServerConf = shuffleServerConfWithoutPort(0, tmpDir, ServerType.GRPC);
     shuffleServerConf.set(ShuffleServerConf.STORAGE_MEDIA_PROVIDER_ENV_KEY, "RSS_ENV_KEY");
     String baseDir = shuffleServerConf.get(ShuffleServerConf.RSS_STORAGE_BASE_PATH).get(0);
     shuffleServerConf.setString(ShuffleServerConf.RSS_STORAGE_BASE_PATH.key(), baseDir);
@@ -316,7 +316,7 @@ public class CoordinatorGrpcTest extends CoordinatorTestBase {
               ss.start();
               grpcShuffleServers.set(0, ss);
             });
-    Thread.sleep(2000);
+    Thread.sleep(3000);
     assertEquals(2, coordinators.get(0).getClusterManager().getNodesNum());
     nodes = scm.getServerList(Sets.newHashSet(Constants.SHUFFLE_SERVER_VERSION, "SSD"));
     assertEquals(1, nodes.size());

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/CoordinatorGrpcTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/CoordinatorGrpcTest.java
@@ -159,7 +159,7 @@ public class CoordinatorGrpcTest extends CoordinatorTestBase {
               ss.start();
               grpcShuffleServers.set(0, ss);
             });
-    Thread.sleep(5000);
+    Thread.sleep(4000);
     CoordinatorServer coordinatorServer = coordinators.get(0);
     ((SimpleClusterManager) (coordinatorServer.getClusterManager())).nodesCheckTest();
 
@@ -316,6 +316,7 @@ public class CoordinatorGrpcTest extends CoordinatorTestBase {
               ss.start();
               grpcShuffleServers.set(0, ss);
             });
+    Thread.sleep(2000);
     assertEquals(2, coordinators.get(0).getClusterManager().getNodesNum());
     nodes = scm.getServerList(Sets.newHashSet(Constants.SHUFFLE_SERVER_VERSION, "SSD"));
     assertEquals(1, nodes.size());

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/CoordinatorReconfigureNodeMaxTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/CoordinatorReconfigureNodeMaxTest.java
@@ -65,8 +65,6 @@ public class CoordinatorReconfigureNodeMaxTest extends CoordinatorTestBase {
     coordinatorConf2.setLong(CoordinatorConf.COORDINATOR_APP_EXPIRED, 2000);
     coordinatorConf2.setInteger(
         CoordinatorConf.COORDINATOR_SHUFFLE_NODES_MAX, DEFAULT_SHUFFLE_NODES_MAX);
-    coordinatorConf2.setInteger(CoordinatorConf.RPC_SERVER_PORT, COORDINATOR_PORT_2);
-    coordinatorConf2.setInteger(CoordinatorConf.JETTY_HTTP_PORT, JETTY_PORT_2);
     coordinatorConf2.setLong(RssBaseConf.RSS_RECONFIGURE_INTERVAL_SEC, 1L);
     storeCoordinatorConf(coordinatorConf2);
 

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/CoordinatorReconfigureNodeMaxTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/CoordinatorReconfigureNodeMaxTest.java
@@ -20,7 +20,6 @@ package org.apache.uniffle.test;
 import java.io.File;
 import java.io.FileWriter;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.concurrent.TimeUnit;
 
@@ -49,48 +48,40 @@ public class CoordinatorReconfigureNodeMaxTest extends CoordinatorTestBase {
   private static final int SERVER_NUM = 10;
   private static final HashSet<String> TAGS = Sets.newHashSet("t1");
 
-  private static final String QUORUM =
-      LOCALHOST + ":" + COORDINATOR_PORT_1 + "," + LOCALHOST + ":" + COORDINATOR_PORT_2;
-
   private static String tempConfFilePath;
 
   @BeforeAll
   public static void setupServers(@TempDir File tmpDir) throws Exception {
-    CoordinatorConf coordinatorConf1 = getCoordinatorConf();
+    CoordinatorConf coordinatorConf1 = coordinatorConfWithoutPort();
     coordinatorConf1.setLong(CoordinatorConf.COORDINATOR_APP_EXPIRED, 2000);
     coordinatorConf1.setInteger(
         CoordinatorConf.COORDINATOR_SHUFFLE_NODES_MAX, DEFAULT_SHUFFLE_NODES_MAX);
     coordinatorConf1.setLong(RssBaseConf.RSS_RECONFIGURE_INTERVAL_SEC, 1L);
     tempConfFilePath = tmpDir.getPath() + "/conf.file";
     ReconfigurableConfManager.init(coordinatorConf1, tempConfFilePath);
-    createCoordinatorServer(coordinatorConf1);
+    storeCoordinatorConf(coordinatorConf1);
 
-    CoordinatorConf coordinatorConf2 = getCoordinatorConf();
+    CoordinatorConf coordinatorConf2 = coordinatorConfWithoutPort();
     coordinatorConf2.setLong(CoordinatorConf.COORDINATOR_APP_EXPIRED, 2000);
     coordinatorConf2.setInteger(
         CoordinatorConf.COORDINATOR_SHUFFLE_NODES_MAX, DEFAULT_SHUFFLE_NODES_MAX);
     coordinatorConf2.setInteger(CoordinatorConf.RPC_SERVER_PORT, COORDINATOR_PORT_2);
     coordinatorConf2.setInteger(CoordinatorConf.JETTY_HTTP_PORT, JETTY_PORT_2);
     coordinatorConf2.setLong(RssBaseConf.RSS_RECONFIGURE_INTERVAL_SEC, 1L);
-    createCoordinatorServer(coordinatorConf2);
+    storeCoordinatorConf(coordinatorConf2);
 
     for (int i = 0; i < SERVER_NUM; i++) {
-      ShuffleServerConf shuffleServerConf = getShuffleServerConf(ServerType.GRPC);
-      File dataDir = new File(tmpDir, "data" + i);
-      String basePath = dataDir.getAbsolutePath();
+      ShuffleServerConf shuffleServerConf =
+          shuffleServerConfWithoutPort(i, tmpDir, ServerType.GRPC);
       shuffleServerConf.setString(
           ShuffleServerConf.RSS_STORAGE_TYPE.key(), StorageType.MEMORY_LOCALFILE_HDFS.name());
-      shuffleServerConf.set(ShuffleServerConf.RSS_STORAGE_BASE_PATH, Arrays.asList(basePath));
       shuffleServerConf.set(RssBaseConf.RPC_METRICS_ENABLED, true);
       shuffleServerConf.set(ShuffleServerConf.SERVER_APP_EXPIRED_WITHOUT_HEARTBEAT, 2000L);
       shuffleServerConf.set(ShuffleServerConf.SERVER_PRE_ALLOCATION_EXPIRED, 5000L);
-      shuffleServerConf.setInteger(RssBaseConf.RPC_SERVER_PORT, 18001 + i);
-      shuffleServerConf.setInteger(RssBaseConf.JETTY_HTTP_PORT, 19010 + i);
       shuffleServerConf.set(ShuffleServerConf.TAGS, new ArrayList<>(TAGS));
-      shuffleServerConf.setString("rss.coordinator.quorum", QUORUM);
-      createShuffleServer(shuffleServerConf);
+      storeShuffleServerConf(shuffleServerConf);
     }
-    startServers();
+    startServersWithRandomPorts();
 
     Thread.sleep(1000 * 5);
   }
@@ -117,7 +108,7 @@ public class CoordinatorReconfigureNodeMaxTest extends CoordinatorTestBase {
             .unregisterThreadPoolSize(10)
             .unregisterRequestTimeSec(10)
             .build();
-    shuffleWriteClient.registerCoordinators(COORDINATOR_QUORUM);
+    shuffleWriteClient.registerCoordinators(getQuorum());
     ShuffleAssignmentsInfo info =
         shuffleWriteClient.getShuffleAssignments("app1", 0, 10, 1, TAGS, SERVER_NUM + 10, -1);
     assertEquals(DEFAULT_SHUFFLE_NODES_MAX, info.getServerToPartitionRanges().keySet().size());

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/CoordinatorTestBase.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/CoordinatorTestBase.java
@@ -29,11 +29,17 @@ public class CoordinatorTestBase extends IntegrationTestBase {
   protected CoordinatorClientFactory factory = CoordinatorClientFactory.getInstance();
   protected CoordinatorGrpcClient coordinatorClient;
 
+  protected CoordinatorGrpcClient getCoordinatorClient() {
+    return (CoordinatorGrpcClient)
+        factory.createCoordinatorClient(
+            ClientType.GRPC, LOCALHOST, coordinators.get(0).getRpcListenPort());
+  }
+
   @BeforeEach
   public void createClient() {
-    coordinatorClient =
-        (CoordinatorGrpcClient)
-            factory.createCoordinatorClient(ClientType.GRPC, LOCALHOST, COORDINATOR_PORT_1);
+    if (!coordinators.isEmpty()) {
+      coordinatorClient = getCoordinatorClient();
+    }
   }
 
   @AfterEach

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/DiskErrorToleranceTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/DiskErrorToleranceTest.java
@@ -53,7 +53,6 @@ import org.apache.uniffle.common.ShuffleBlockInfo;
 import org.apache.uniffle.common.ShuffleServerInfo;
 import org.apache.uniffle.common.rpc.ServerType;
 import org.apache.uniffle.common.rpc.StatusCode;
-import org.apache.uniffle.coordinator.CoordinatorConf;
 import org.apache.uniffle.server.ShuffleServerConf;
 import org.apache.uniffle.storage.util.StorageType;
 
@@ -73,14 +72,10 @@ public class DiskErrorToleranceTest extends ShuffleReadWriteBase {
   public static void setupServers(@TempDir File serverTmpDir) throws Exception {
     data1 = new File(serverTmpDir, "data1");
     data2 = new File(serverTmpDir, "data2");
-    CoordinatorConf coordinatorConf = getCoordinatorConf();
-    createCoordinatorServer(coordinatorConf);
+    storeCoordinatorConf(coordinatorConfWithoutPort());
 
-    ShuffleServerConf grpcShuffleServerConf = buildShuffleServerConf(ServerType.GRPC);
-    storeShuffleServerConf(grpcShuffleServerConf);
-
-    ShuffleServerConf nettyShuffleServerConf = buildShuffleServerConf(ServerType.GRPC_NETTY);
-    storeShuffleServerConf(nettyShuffleServerConf);
+    storeShuffleServerConf(buildShuffleServerConf(ServerType.GRPC));
+    storeShuffleServerConf(buildShuffleServerConf(ServerType.GRPC_NETTY));
 
     startServersWithRandomPorts();
   }

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/HealthCheckCoordinatorGrpcTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/HealthCheckCoordinatorGrpcTest.java
@@ -69,38 +69,38 @@ public class HealthCheckCoordinatorGrpcTest extends CoordinatorTestBase {
     long usedSize = serverTmpDir.getTotalSpace() - serverTmpDir.getUsableSpace();
     maxUsage = (writeDataSize * 0.75 + usedSize) * 100.0 / totalSize;
     healthUsage = (writeDataSize * 0.5 + usedSize) * 100.0 / totalSize;
-    CoordinatorConf coordinatorConf = getCoordinatorConf();
+    CoordinatorConf coordinatorConf = coordinatorConfWithoutPort();
     coordinatorConf.setLong(CoordinatorConf.COORDINATOR_APP_EXPIRED, 2000);
     coordinatorConf.setLong(CoordinatorConf.COORDINATOR_HEARTBEAT_TIMEOUT, 3000);
-    createCoordinatorServer(coordinatorConf);
-    ShuffleServerConf shuffleServerConf = getShuffleServerConf(ServerType.GRPC);
-    shuffleServerConf.setBoolean(ShuffleServerConf.HEALTH_CHECK_ENABLE, true);
-    shuffleServerConf.setString(
+    storeCoordinatorConf(coordinatorConf);
+
+    ShuffleServerConf shuffleServerConf1 =
+        shuffleServerConfWithoutPort(0, serverTmpDir, ServerType.GRPC);
+    shuffleServerConf1.setBoolean(ShuffleServerConf.HEALTH_CHECK_ENABLE, true);
+    shuffleServerConf1.setString(
         ShuffleServerConf.RSS_STORAGE_TYPE.key(), StorageType.LOCALFILE.name());
-    shuffleServerConf.set(
+    shuffleServerConf1.set(
         ShuffleServerConf.RSS_STORAGE_BASE_PATH, Arrays.asList(data1.getAbsolutePath()));
-    shuffleServerConf.setDouble(
+    shuffleServerConf1.setDouble(
         ShuffleServerConf.HEALTH_STORAGE_RECOVERY_USAGE_PERCENTAGE, healthUsage);
-    shuffleServerConf.setDouble(ShuffleServerConf.HEALTH_STORAGE_MAX_USAGE_PERCENTAGE, maxUsage);
-    shuffleServerConf.setLong(ShuffleServerConf.HEALTH_CHECK_INTERVAL, 1000L);
-    createShuffleServer(shuffleServerConf);
-    shuffleServerConf.setInteger(
-        ShuffleServerConf.RPC_SERVER_PORT,
-        shuffleServerConf.getInteger(ShuffleServerConf.RPC_SERVER_PORT) + 1);
-    shuffleServerConf.setInteger(
-        ShuffleServerConf.JETTY_HTTP_PORT,
-        shuffleServerConf.getInteger(ShuffleServerConf.JETTY_HTTP_PORT) + 1);
-    shuffleServerConf.setString(
+    shuffleServerConf1.setDouble(ShuffleServerConf.HEALTH_STORAGE_MAX_USAGE_PERCENTAGE, maxUsage);
+    shuffleServerConf1.setLong(ShuffleServerConf.HEALTH_CHECK_INTERVAL, 1000L);
+    storeShuffleServerConf(shuffleServerConf1);
+
+    ShuffleServerConf shuffleServerConf2 =
+        shuffleServerConfWithoutPort(1, serverTmpDir, ServerType.GRPC);
+    shuffleServerConf2.setString(
         ShuffleServerConf.RSS_STORAGE_TYPE.key(), StorageType.LOCALFILE.name());
-    shuffleServerConf.set(
+    shuffleServerConf2.set(
         ShuffleServerConf.RSS_STORAGE_BASE_PATH, Arrays.asList(data2.getAbsolutePath()));
-    shuffleServerConf.setDouble(
+    shuffleServerConf2.setDouble(
         ShuffleServerConf.HEALTH_STORAGE_RECOVERY_USAGE_PERCENTAGE, healthUsage);
-    shuffleServerConf.setDouble(ShuffleServerConf.HEALTH_STORAGE_MAX_USAGE_PERCENTAGE, maxUsage);
-    shuffleServerConf.setLong(ShuffleServerConf.HEALTH_CHECK_INTERVAL, 1000L);
-    shuffleServerConf.setBoolean(ShuffleServerConf.HEALTH_CHECK_ENABLE, true);
-    createShuffleServer(shuffleServerConf);
-    startServers();
+    shuffleServerConf2.setDouble(ShuffleServerConf.HEALTH_STORAGE_MAX_USAGE_PERCENTAGE, maxUsage);
+    shuffleServerConf2.setLong(ShuffleServerConf.HEALTH_CHECK_INTERVAL, 1000L);
+    shuffleServerConf2.setBoolean(ShuffleServerConf.HEALTH_CHECK_ENABLE, true);
+    storeShuffleServerConf(shuffleServerConf2);
+
+    startServersWithRandomPorts();
   }
 
   @Test

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/HealthCheckTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/HealthCheckTest.java
@@ -37,7 +37,7 @@ import org.apache.uniffle.storage.util.StorageType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class HealthCheckTest extends CoordinatorTestBase {
+public class HealthCheckTest {
   @BeforeAll
   public static void setup() {
     ShuffleServerMetrics.register();

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/HybridStorageFaultToleranceBase.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/HybridStorageFaultToleranceBase.java
@@ -51,7 +51,6 @@ import org.apache.uniffle.common.PartitionRange;
 import org.apache.uniffle.common.ShuffleBlockInfo;
 import org.apache.uniffle.common.ShuffleServerInfo;
 import org.apache.uniffle.common.rpc.StatusCode;
-import org.apache.uniffle.server.ShuffleServerConf;
 import org.apache.uniffle.storage.util.StorageType;
 
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -60,21 +59,18 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public abstract class HybridStorageFaultToleranceBase extends ShuffleReadWriteBase {
   protected ShuffleServerGrpcClient grpcShuffleServerClient;
   protected ShuffleServerGrpcNettyClient nettyShuffleServerClient;
-  protected static ShuffleServerConf grpcShuffleServerConfig;
-  protected static ShuffleServerConf nettyShuffleServerConfig;
   private static String REMOTE_STORAGE = HDFS_URI + "rss/multi_storage_fault_%s";
 
   @BeforeEach
   public void createClient() throws Exception {
     ShuffleServerClientFactory.getInstance().cleanupCache();
     grpcShuffleServerClient =
-        new ShuffleServerGrpcClient(
-            LOCALHOST, grpcShuffleServerConfig.getInteger(ShuffleServerConf.RPC_SERVER_PORT));
+        new ShuffleServerGrpcClient(LOCALHOST, grpcShuffleServers.get(0).getGrpcPort());
     nettyShuffleServerClient =
         new ShuffleServerGrpcNettyClient(
             LOCALHOST,
-            nettyShuffleServerConfig.getInteger(ShuffleServerConf.RPC_SERVER_PORT),
-            nettyShuffleServerConfig.getInteger(ShuffleServerConf.NETTY_SERVER_PORT));
+            nettyShuffleServers.get(0).getGrpcPort(),
+            nettyShuffleServers.get(0).getNettyPort());
   }
 
   @AfterEach
@@ -164,10 +160,9 @@ public abstract class HybridStorageFaultToleranceBase extends ShuffleReadWriteBa
         isNettyMode
             ? new ShuffleServerInfo(
                 LOCALHOST,
-                nettyShuffleServerConfig.getInteger(ShuffleServerConf.RPC_SERVER_PORT),
-                nettyShuffleServerConfig.getInteger(ShuffleServerConf.NETTY_SERVER_PORT))
-            : new ShuffleServerInfo(
-                LOCALHOST, grpcShuffleServerConfig.getInteger(ShuffleServerConf.RPC_SERVER_PORT));
+                nettyShuffleServers.get(0).getGrpcPort(),
+                nettyShuffleServers.get(0).getNettyPort())
+            : new ShuffleServerInfo(LOCALHOST, grpcShuffleServers.get(0).getGrpcPort());
     ShuffleReadClientImpl readClient =
         ShuffleClientFactory.newReadBuilder()
             .clientType(isNettyMode ? ClientType.GRPC_NETTY : ClientType.GRPC)

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/HybridStorageHadoopFallbackTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/HybridStorageHadoopFallbackTest.java
@@ -18,17 +18,11 @@
 package org.apache.uniffle.test;
 
 import java.io.File;
-import java.util.Arrays;
 
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.io.TempDir;
 
-import org.apache.uniffle.client.factory.ShuffleServerClientFactory;
-import org.apache.uniffle.client.impl.grpc.ShuffleServerGrpcClient;
-import org.apache.uniffle.client.impl.grpc.ShuffleServerGrpcNettyClient;
 import org.apache.uniffle.common.rpc.ServerType;
-import org.apache.uniffle.coordinator.CoordinatorConf;
 import org.apache.uniffle.server.ShuffleServerConf;
 import org.apache.uniffle.storage.util.StorageType;
 
@@ -38,27 +32,18 @@ public class HybridStorageHadoopFallbackTest extends HybridStorageFaultTolerance
 
   @BeforeAll
   public static void setupServers(@TempDir File tmpDir) throws Exception {
-    final CoordinatorConf coordinatorConf = getCoordinatorConf();
-    createCoordinatorServer(coordinatorConf);
+    storeCoordinatorConf(coordinatorConfWithoutPort());
 
-    String basePath = generateBasePath(tmpDir);
+    storeShuffleServerConf(buildShuffleServerConf(0, tmpDir, ServerType.GRPC));
+    storeShuffleServerConf(buildShuffleServerConf(0, tmpDir, ServerType.GRPC_NETTY));
 
-    ShuffleServerConf grpcShuffleServerConf = buildShuffleServerConf(ServerType.GRPC, basePath);
-    createShuffleServer(grpcShuffleServerConf);
-
-    ShuffleServerConf nettyShuffleServerConf =
-        buildShuffleServerConf(ServerType.GRPC_NETTY, basePath);
-    createShuffleServer(nettyShuffleServerConf);
-
-    startServers();
-
-    grpcShuffleServerConfig = grpcShuffleServerConf;
-    nettyShuffleServerConfig = nettyShuffleServerConf;
+    startServersWithRandomPorts();
   }
 
-  private static ShuffleServerConf buildShuffleServerConf(ServerType serverType, String basePath)
-      throws Exception {
-    ShuffleServerConf shuffleServerConf = getShuffleServerConf(serverType);
+  private static ShuffleServerConf buildShuffleServerConf(
+      int subDirIndex, File tmpDir, ServerType serverType) {
+    ShuffleServerConf shuffleServerConf =
+        shuffleServerConfWithoutPort(subDirIndex, tmpDir, serverType);
     shuffleServerConf.setDouble(ShuffleServerConf.CLEANUP_THRESHOLD, 0.0);
     shuffleServerConf.setDouble(ShuffleServerConf.HIGH_WATER_MARK_OF_WRITE, 100.0);
     shuffleServerConf.setLong(ShuffleServerConf.DISK_CAPACITY, 1024L * 1024L * 100);
@@ -68,23 +53,9 @@ public class HybridStorageHadoopFallbackTest extends HybridStorageFaultTolerance
     shuffleServerConf.setLong(ShuffleServerConf.SERVER_COMMIT_TIMEOUT, 20L * 1000L);
     shuffleServerConf.setString(
         ShuffleServerConf.RSS_STORAGE_TYPE.key(), StorageType.LOCALFILE_HDFS.name());
-    shuffleServerConf.set(ShuffleServerConf.RSS_STORAGE_BASE_PATH, Arrays.asList(basePath));
     shuffleServerConf.setLong(
         ShuffleServerConf.FLUSH_COLD_STORAGE_THRESHOLD_SIZE, 1L * 1024L * 1024L);
     return shuffleServerConf;
-  }
-
-  @BeforeEach
-  public void createClient() throws Exception {
-    ShuffleServerClientFactory.getInstance().cleanupCache();
-    grpcShuffleServerClient =
-        new ShuffleServerGrpcClient(
-            LOCALHOST, grpcShuffleServerConfig.getInteger(ShuffleServerConf.RPC_SERVER_PORT));
-    nettyShuffleServerClient =
-        new ShuffleServerGrpcNettyClient(
-            LOCALHOST,
-            nettyShuffleServerConfig.getInteger(ShuffleServerConf.RPC_SERVER_PORT),
-            nettyShuffleServerConfig.getInteger(ShuffleServerConf.NETTY_SERVER_PORT));
   }
 
   @Override

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/HybridStorageLocalFileFallbackTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/HybridStorageLocalFileFallbackTest.java
@@ -18,7 +18,6 @@
 package org.apache.uniffle.test;
 
 import java.io.File;
-import java.util.Arrays;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -41,40 +40,31 @@ public class HybridStorageLocalFileFallbackTest extends HybridStorageFaultTolera
 
   @BeforeAll
   public static void setupServers(@TempDir File tmpDir) throws Exception {
-    final CoordinatorConf coordinatorConf = getCoordinatorConf();
-    createCoordinatorServer(coordinatorConf);
+    final CoordinatorConf coordinatorConf = coordinatorConfWithoutPort();
+    storeCoordinatorConf(coordinatorConf);
 
-    String basePath = generateBasePath(tmpDir);
+    storeShuffleServerConf(buildShuffleServerConf(0, tmpDir, ServerType.GRPC));
+    storeShuffleServerConf(buildShuffleServerConf(0, tmpDir, ServerType.GRPC_NETTY));
 
-    ShuffleServerConf grpcShuffleServerConf = buildShuffleServerConf(ServerType.GRPC, basePath);
-    createShuffleServer(grpcShuffleServerConf);
-
-    ShuffleServerConf nettyShuffleServerConf =
-        buildShuffleServerConf(ServerType.GRPC_NETTY, basePath);
-    createShuffleServer(nettyShuffleServerConf);
-
-    startServers();
-
-    grpcShuffleServerConfig = grpcShuffleServerConf;
-    nettyShuffleServerConfig = nettyShuffleServerConf;
+    startServersWithRandomPorts();
   }
 
   @BeforeEach
   public void createClient() throws Exception {
     ShuffleServerClientFactory.getInstance().cleanupCache();
     grpcShuffleServerClient =
-        new ShuffleServerGrpcClient(
-            LOCALHOST, grpcShuffleServerConfig.getInteger(ShuffleServerConf.RPC_SERVER_PORT));
+        new ShuffleServerGrpcClient(LOCALHOST, grpcShuffleServers.get(0).getGrpcPort());
     nettyShuffleServerClient =
         new ShuffleServerGrpcNettyClient(
             LOCALHOST,
-            nettyShuffleServerConfig.getInteger(ShuffleServerConf.RPC_SERVER_PORT),
-            nettyShuffleServerConfig.getInteger(ShuffleServerConf.NETTY_SERVER_PORT));
+            nettyShuffleServers.get(0).getGrpcPort(),
+            nettyShuffleServers.get(0).getNettyPort());
   }
 
-  private static ShuffleServerConf buildShuffleServerConf(ServerType serverType, String basePath)
-      throws Exception {
-    ShuffleServerConf shuffleServerConf = getShuffleServerConf(serverType);
+  private static ShuffleServerConf buildShuffleServerConf(
+      int subDirIndex, File tmpDir, ServerType serverType) {
+    ShuffleServerConf shuffleServerConf =
+        shuffleServerConfWithoutPort(subDirIndex, tmpDir, serverType);
     shuffleServerConf.setDouble(ShuffleServerConf.CLEANUP_THRESHOLD, 0.0);
     shuffleServerConf.setDouble(ShuffleServerConf.HIGH_WATER_MARK_OF_WRITE, 100.0);
     shuffleServerConf.setLong(ShuffleServerConf.DISK_CAPACITY, 1024L * 1024L * 100);
@@ -84,7 +74,6 @@ public class HybridStorageLocalFileFallbackTest extends HybridStorageFaultTolera
     shuffleServerConf.setLong(ShuffleServerConf.SERVER_COMMIT_TIMEOUT, 20L * 1000L);
     shuffleServerConf.setString(
         ShuffleServerConf.RSS_STORAGE_TYPE.key(), StorageType.LOCALFILE_HDFS.name());
-    shuffleServerConf.set(ShuffleServerConf.RSS_STORAGE_BASE_PATH, Arrays.asList(basePath));
     shuffleServerConf.setLong(
         ShuffleServerConf.FLUSH_COLD_STORAGE_THRESHOLD_SIZE, 1000L * 1024L * 1024L);
     shuffleServerConf.setString(

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/IntegrationTestBase.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/IntegrationTestBase.java
@@ -171,7 +171,7 @@ public abstract class IntegrationTestBase extends HadoopTestBase {
   protected static List<Integer> jettyPorts = Lists.newArrayList();
 
   public static List<Integer> reserveJettyPorts(int numPorts) {
-    ArrayList<Integer> ports = new ArrayList<>(numPorts);
+    List<Integer> ports = new ArrayList<>(numPorts);
     for (int i = 0; i < numPorts; i++) {
       int port = PortRegistry.reservePort();
       jettyPorts.add(port);

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/IntegrationTestBase.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/IntegrationTestBase.java
@@ -21,12 +21,16 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.PrintWriter;
 import java.nio.file.Files;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -97,6 +101,32 @@ public abstract class IntegrationTestBase extends HadoopTestBase {
     }
   }
 
+  public static String getQuorum() {
+    return coordinators.stream()
+        .map(CoordinatorServer::getRpcListenPort)
+        .map(port -> LOCALHOST + ":" + port)
+        .collect(Collectors.joining(","));
+  }
+
+  public static List<Integer> generateNonExistingPorts(int num) {
+    Set<Integer> portExistsSet = Sets.newHashSet();
+    jettyPorts.forEach(port -> portExistsSet.add(port));
+    coordinators.forEach(server -> portExistsSet.add(server.getRpcListenPort()));
+    grpcShuffleServers.forEach(server -> portExistsSet.add(server.getGrpcPort()));
+    nettyShuffleServers.forEach(server -> portExistsSet.add(server.getGrpcPort()));
+    nettyShuffleServers.forEach(server -> portExistsSet.add(server.getNettyPort()));
+    int i = 0;
+    List<Integer> fakePorts = new ArrayList<>(num);
+    while (i < num) {
+      int port = ThreadLocalRandom.current().nextInt(1024, 65535);
+      if (portExistsSet.add(port)) {
+        fakePorts.add(port);
+        i++;
+      }
+    }
+    return fakePorts;
+  }
+
   public static void startServersWithRandomPorts() throws Exception {
     final int jettyPortSize =
         coordinatorConfList.size()
@@ -113,11 +143,7 @@ public abstract class IntegrationTestBase extends HadoopTestBase {
     for (CoordinatorServer coordinator : coordinators) {
       coordinator.start();
     }
-    String quorum =
-        coordinators.stream()
-            .map(CoordinatorServer::getRpcListenPort)
-            .map(port -> LOCALHOST + ":" + port)
-            .collect(Collectors.joining(","));
+    String quorum = getQuorum();
 
     for (ShuffleServerConf serverConf : shuffleServerConfList) {
       serverConf.setInteger(RssBaseConf.JETTY_HTTP_PORT, jettyPorts.get(index));
@@ -144,10 +170,14 @@ public abstract class IntegrationTestBase extends HadoopTestBase {
 
   protected static List<Integer> jettyPorts = Lists.newArrayList();
 
-  public static void reserveJettyPorts(int numPorts) {
+  public static List<Integer> reserveJettyPorts(int numPorts) {
+    ArrayList<Integer> ports = new ArrayList<>(numPorts);
     for (int i = 0; i < numPorts; i++) {
-      jettyPorts.add(PortRegistry.reservePort());
+      int port = PortRegistry.reservePort();
+      jettyPorts.add(port);
+      ports.add(port);
     }
+    return ports;
   }
 
   @AfterAll
@@ -242,10 +272,12 @@ public abstract class IntegrationTestBase extends HadoopTestBase {
   protected static ShuffleServerConf shuffleServerConfWithoutPort(
       int subDirIndex, File tmpDir, ServerType serverType) {
     ShuffleServerConf shuffleServerConf = getShuffleServerConf(serverType, "", 0, 0, 0);
-    File dataDir1 = new File(tmpDir, subDirIndex + "_1");
-    File dataDir2 = new File(tmpDir, subDirIndex + "_2");
-    String basePath = dataDir1.getAbsolutePath() + "," + dataDir2.getAbsolutePath();
-    shuffleServerConf.setString("rss.storage.basePath", basePath);
+    if (tmpDir != null) {
+      File dataDir1 = new File(tmpDir, subDirIndex + "_1");
+      File dataDir2 = new File(tmpDir, subDirIndex + "_2");
+      String basePath = dataDir1.getAbsolutePath() + "," + dataDir2.getAbsolutePath();
+      shuffleServerConf.setString("rss.storage.basePath", basePath);
+    }
     return shuffleServerConf;
   }
 
@@ -303,13 +335,6 @@ public abstract class IntegrationTestBase extends HadoopTestBase {
       default:
         throw new UnsupportedOperationException("Unsupported server type " + serverType);
     }
-  }
-
-  protected static void createAndStartServers(
-      ShuffleServerConf shuffleServerConf, CoordinatorConf coordinatorConf) throws Exception {
-    createCoordinatorServer(coordinatorConf);
-    createShuffleServer(shuffleServerConf);
-    startServers();
   }
 
   protected static File createDynamicConfFile(Map<String, String> dynamicConf) throws Exception {

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/QuorumTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/QuorumTest.java
@@ -600,6 +600,7 @@ public class QuorumTest extends ShuffleReadWriteBase {
     assertEquals(blockIdBitmap, succBlockIdBitmap);
 
     // tricky to reserve port, it'll be released after test
+    @SuppressWarnings("checkstyle:VariableDeclarationUsageDistance")
     List<Integer> ports = reserveJettyPorts(2);
     // when one server is restarted, getShuffleResult should success
     grpcShuffleServers.get(1).stopServer();

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/RemoteMergeShuffleWithRssClientTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/RemoteMergeShuffleWithRssClientTest.java
@@ -19,7 +19,6 @@ package org.apache.uniffle.test;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.ServerSocket;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -65,7 +64,6 @@ import org.apache.uniffle.common.util.BlockIdLayout;
 import org.apache.uniffle.common.util.ChecksumUtils;
 import org.apache.uniffle.coordinator.CoordinatorConf;
 import org.apache.uniffle.proto.RssProtos;
-import org.apache.uniffle.server.ShuffleServer;
 import org.apache.uniffle.server.ShuffleServerConf;
 import org.apache.uniffle.server.buffer.ShuffleBufferType;
 import org.apache.uniffle.storage.util.StorageType;
@@ -84,49 +82,26 @@ public class RemoteMergeShuffleWithRssClientTest extends ShuffleReadWriteBase {
 
   @BeforeAll
   public static void setupServers(@TempDir File tmpDir) throws Exception {
-    CoordinatorConf coordinatorConf = getCoordinatorConf();
+    CoordinatorConf coordinatorConf = coordinatorConfWithoutPort();
     coordinatorConf.setBoolean(COORDINATOR_DYNAMIC_CLIENT_CONF_ENABLED, false);
-    createCoordinatorServer(coordinatorConf);
-    ShuffleServerConf shuffleServerConf = getShuffleServerConf(ServerType.GRPC_NETTY);
+    storeCoordinatorConf(coordinatorConf);
+
+    ShuffleServerConf shuffleServerConf =
+        shuffleServerConfWithoutPort(0, tmpDir, ServerType.GRPC_NETTY);
     shuffleServerConf.set(ShuffleServerConf.SERVER_MERGE_ENABLE, true);
     shuffleServerConf.set(ShuffleServerConf.SERVER_MERGE_DEFAULT_MERGED_BLOCK_SIZE, "1k");
     shuffleServerConf.set(
         ShuffleServerConf.SERVER_SHUFFLE_BUFFER_TYPE, ShuffleBufferType.SKIP_LIST);
     shuffleServerConf.setLong("rss.server.app.expired.withoutHeartbeat", 10000000);
-    File dataDir1 = new File(tmpDir, "data1");
-    File dataDir2 = new File(tmpDir, "data2");
-    String basePath = dataDir1.getAbsolutePath() + "," + dataDir2.getAbsolutePath();
     shuffleServerConf.setString("rss.storage.type", StorageType.LOCALFILE.name());
-    shuffleServerConf.setString("rss.storage.basePath", basePath);
-    List<Integer> ports = findAvailablePorts(2);
-    shuffleServerConf.setInteger("rss.rpc.server.port", ports.get(0));
-    shuffleServerConf.setInteger("rss.jetty.http.port", ports.get(1));
-    createShuffleServer(shuffleServerConf);
-    startServers();
-    ShuffleServer shuffleServer = nettyShuffleServers.get(0);
+    storeShuffleServerConf(shuffleServerConf);
+
+    startServersWithRandomPorts();
     shuffleServerInfo =
         new ShuffleServerInfo(
-            "127.0.0.1-20001",
-            shuffleServer.getIp(),
-            shuffleServer.getGrpcPort(),
-            shuffleServer.getNettyPort());
-  }
-
-  private static List<Integer> findAvailablePorts(int num) throws IOException {
-    List<ServerSocket> sockets = new ArrayList<>();
-    List<Integer> ports = new ArrayList<>();
-
-    for (int i = 0; i < num; i++) {
-      ServerSocket socket = new ServerSocket(0);
-      ports.add(socket.getLocalPort());
-      sockets.add(socket);
-    }
-
-    for (ServerSocket socket : sockets) {
-      socket.close();
-    }
-
-    return ports;
+            LOCALHOST,
+            nettyShuffleServers.get(0).getGrpcPort(),
+            nettyShuffleServers.get(0).getNettyPort());
   }
 
   public void createClient(String clientType) {

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/RemoteMergeShuffleWithRssClientTestWhenShuffleFlushed.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/RemoteMergeShuffleWithRssClientTestWhenShuffleFlushed.java
@@ -19,7 +19,6 @@ package org.apache.uniffle.test;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.ServerSocket;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -66,7 +65,6 @@ import org.apache.uniffle.common.util.BlockIdLayout;
 import org.apache.uniffle.common.util.ChecksumUtils;
 import org.apache.uniffle.coordinator.CoordinatorConf;
 import org.apache.uniffle.proto.RssProtos;
-import org.apache.uniffle.server.ShuffleServer;
 import org.apache.uniffle.server.ShuffleServerConf;
 import org.apache.uniffle.server.buffer.ShuffleBufferType;
 import org.apache.uniffle.server.storage.MultiPartLocalStorageManager;
@@ -89,15 +87,18 @@ public class RemoteMergeShuffleWithRssClientTestWhenShuffleFlushed extends Shuff
 
   @BeforeAll
   public static void setupServers(@TempDir File tmpDir) throws Exception {
-    CoordinatorConf coordinatorConf = getCoordinatorConf();
+    CoordinatorConf coordinatorConf = coordinatorConfWithoutPort();
     coordinatorConf.setBoolean(COORDINATOR_DYNAMIC_CLIENT_CONF_ENABLED, false);
-    ShuffleServerConf shuffleServerConf = getShuffleServerConf(ServerType.GRPC_NETTY);
+    storeCoordinatorConf(coordinatorConf);
+
+    ShuffleServerConf shuffleServerConf =
+        shuffleServerConfWithoutPort(0, tmpDir, ServerType.GRPC_NETTY);
     Assumptions.assumeTrue(
         !shuffleServerConf
             .get(SERVER_LOCAL_STORAGE_MANAGER_CLASS)
             .equals(MultiPartLocalStorageManager.class.getName()),
         MultiPartLocalStorageManager.class.getName() + " is not working with remote merge feature");
-    createCoordinatorServer(coordinatorConf);
+
     shuffleServerConf.set(ShuffleServerConf.SERVER_MERGE_ENABLE, true);
     shuffleServerConf.set(ShuffleServerConf.SERVER_MERGE_DEFAULT_MERGED_BLOCK_SIZE, "1k");
     shuffleServerConf.set(
@@ -106,40 +107,15 @@ public class RemoteMergeShuffleWithRssClientTestWhenShuffleFlushed extends Shuff
     shuffleServerConf.set(SERVER_MEMORY_SHUFFLE_HIGHWATERMARK_PERCENTAGE, 0.0);
     shuffleServerConf.set(SERVER_MEMORY_SHUFFLE_LOWWATERMARK_PERCENTAGE, 0.0);
     shuffleServerConf.setLong("rss.server.app.expired.withoutHeartbeat", 10000000);
-    File dataDir1 = new File(tmpDir, "data1");
-    File dataDir2 = new File(tmpDir, "data2");
-    String basePath = dataDir1.getAbsolutePath() + "," + dataDir2.getAbsolutePath();
     shuffleServerConf.setString("rss.storage.type", StorageType.LOCALFILE.name());
-    shuffleServerConf.setString("rss.storage.basePath", basePath);
-    List<Integer> ports = findAvailablePorts(2);
-    shuffleServerConf.setInteger("rss.rpc.server.port", ports.get(0));
-    shuffleServerConf.setInteger("rss.jetty.http.port", ports.get(1));
-    createShuffleServer(shuffleServerConf);
-    startServers();
-    ShuffleServer shuffleServer = nettyShuffleServers.get(0);
+    storeShuffleServerConf(shuffleServerConf);
+
+    startServersWithRandomPorts();
     shuffleServerInfo =
         new ShuffleServerInfo(
-            "127.0.0.1-20001",
-            shuffleServer.getIp(),
-            shuffleServer.getGrpcPort(),
-            shuffleServer.getNettyPort());
-  }
-
-  private static List<Integer> findAvailablePorts(int num) throws IOException {
-    List<ServerSocket> sockets = new ArrayList<>();
-    List<Integer> ports = new ArrayList<>();
-
-    for (int i = 0; i < num; i++) {
-      ServerSocket socket = new ServerSocket(0);
-      ports.add(socket.getLocalPort());
-      sockets.add(socket);
-    }
-
-    for (ServerSocket socket : sockets) {
-      socket.close();
-    }
-
-    return ports;
+            LOCALHOST,
+            nettyShuffleServers.get(0).getGrpcPort(),
+            nettyShuffleServers.get(0).getNettyPort());
   }
 
   public void createClient(String clientType) {

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleReadWriteBase.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleReadWriteBase.java
@@ -17,7 +17,6 @@
 
 package org.apache.uniffle.test;
 
-import java.io.File;
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
@@ -131,12 +130,6 @@ public abstract class ShuffleReadWriteBase extends IntegrationTestBase {
 
   public static void validateResult(ShuffleReadClient readClient, Map<Long, byte[]> expectedData) {
     TestUtils.validateResult(readClient, expectedData);
-  }
-
-  public static String generateBasePath(File tmpDir) {
-    File dataDir1 = new File(tmpDir, "data1");
-    File dataDir2 = new File(tmpDir, "data2");
-    return dataDir1.getAbsolutePath() + "," + dataDir2.getAbsolutePath();
   }
 
   public static ShuffleDataResult readShuffleData(

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerFaultToleranceTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerFaultToleranceTest.java
@@ -283,8 +283,7 @@ public class ShuffleServerFaultToleranceTest extends ShuffleReadWriteBase {
     return new RssSendShuffleDataRequest(appId, 3, 1000, shuffleToBlocks);
   }
 
-  public static void prepareShuffleServerConf(int subDirIndex, File tmpDir, ServerType serverType)
-      throws Exception {
+  public static void prepareShuffleServerConf(int subDirIndex, File tmpDir, ServerType serverType) {
     ShuffleServerConf shuffleServerConf =
         shuffleServerConfWithoutPort(subDirIndex, tmpDir, serverType);
     shuffleServerConf.setString(

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerInternalGrpcTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerInternalGrpcTest.java
@@ -18,7 +18,6 @@
 package org.apache.uniffle.test;
 
 import java.io.File;
-import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 
 import com.google.common.collect.Lists;
@@ -54,28 +53,26 @@ public class ShuffleServerInternalGrpcTest extends IntegrationTestBase {
   private ShuffleServerGrpcClient shuffleServerClient;
   private ShuffleServerInternalGrpcClient shuffleServerInternalClient;
 
-  private static int rpcPort1;
-
   @BeforeAll
   public static void setupServers(@TempDir File tmpDir) throws Exception {
-    CoordinatorConf coordinatorConf = getCoordinatorConf();
+    CoordinatorConf coordinatorConf = coordinatorConfWithoutPort();
     coordinatorConf.setLong(CoordinatorConf.COORDINATOR_APP_EXPIRED, 2000);
-    createCoordinatorServer(coordinatorConf);
-    ShuffleServerConf shuffleServerConf = getShuffleServerConf(ServerType.GRPC);
-    File dataDir1 = new File(tmpDir, "data1");
-    String basePath = dataDir1.getAbsolutePath();
-    shuffleServerConf.set(ShuffleServerConf.RSS_STORAGE_BASE_PATH, Arrays.asList(basePath));
+    storeCoordinatorConf(coordinatorConf);
+
+    ShuffleServerConf shuffleServerConf = shuffleServerConfWithoutPort(0, tmpDir, ServerType.GRPC);
     shuffleServerConf.set(ShuffleServerConf.SERVER_APP_EXPIRED_WITHOUT_HEARTBEAT, 5000L);
     shuffleServerConf.set(ShuffleServerConf.SERVER_DECOMMISSION_CHECK_INTERVAL, 500L);
-    rpcPort1 = shuffleServerConf.getInteger(ShuffleServerConf.RPC_SERVER_PORT);
-    createShuffleServer(shuffleServerConf);
-    startServers();
+    storeShuffleServerConf(shuffleServerConf);
+
+    startServersWithRandomPorts();
   }
 
   @BeforeEach
   public void createClient() {
-    shuffleServerClient = new ShuffleServerGrpcClient(LOCALHOST, rpcPort1);
-    shuffleServerInternalClient = new ShuffleServerInternalGrpcClient(LOCALHOST, rpcPort1);
+    shuffleServerClient =
+        new ShuffleServerGrpcClient(LOCALHOST, grpcShuffleServers.get(0).getGrpcPort());
+    shuffleServerInternalClient =
+        new ShuffleServerInternalGrpcClient(LOCALHOST, grpcShuffleServers.get(0).getGrpcPort());
   }
 
   @AfterEach

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerWithKerberizedHadoopTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerWithKerberizedHadoopTest.java
@@ -64,6 +64,8 @@ import org.apache.uniffle.server.ShuffleServer;
 import org.apache.uniffle.server.ShuffleServerConf;
 import org.apache.uniffle.storage.util.StorageType;
 
+import static org.apache.uniffle.test.IntegrationTestBase.grpcShuffleServers;
+import static org.apache.uniffle.test.IntegrationTestBase.nettyShuffleServers;
 import static org.apache.uniffle.test.ShuffleReadWriteBase.mockSSI;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -87,11 +89,7 @@ public class ShuffleServerWithKerberizedHadoopTest extends KerberizedHadoopBase 
   private static CoordinatorServer coordinatorServer;
   private static ShuffleServer grpcShuffleServer;
   private static ShuffleServer nettyShuffleServer;
-  private static ShuffleServerConf grpcShuffleServerConfig;
-  private static ShuffleServerConf nettyShuffleServerConfig;
   protected static List<Integer> jettyPorts = Lists.newArrayList();
-
-  static @TempDir File tempDir;
 
   private static ShuffleServerConf getShuffleServerConf(
       int id, File tmpDir, int coordinatorRpcPort, ServerType serverType) throws Exception {
@@ -148,9 +146,6 @@ public class ShuffleServerWithKerberizedHadoopTest extends KerberizedHadoopBase 
             1, tempDir, coordinatorServer.getRpcListenPort(), ServerType.GRPC_NETTY);
     nettyShuffleServer = new ShuffleServer(nettyShuffleServerConf);
     nettyShuffleServer.start();
-
-    grpcShuffleServerConfig = grpcShuffleServerConf;
-    nettyShuffleServerConfig = nettyShuffleServerConf;
   }
 
   @AfterAll
@@ -295,10 +290,9 @@ public class ShuffleServerWithKerberizedHadoopTest extends KerberizedHadoopBase 
         isNettyMode
             ? new ShuffleServerInfo(
                 LOCALHOST,
-                nettyShuffleServerConfig.getInteger(ShuffleServerConf.RPC_SERVER_PORT),
-                nettyShuffleServerConfig.getInteger(ShuffleServerConf.NETTY_SERVER_PORT))
-            : new ShuffleServerInfo(
-                LOCALHOST, grpcShuffleServerConfig.getInteger(ShuffleServerConf.RPC_SERVER_PORT));
+                nettyShuffleServers.get(0).getGrpcPort(),
+                nettyShuffleServers.get(0).getNettyPort())
+            : new ShuffleServerInfo(LOCALHOST, grpcShuffleServers.get(0).getGrpcPort());
     ShuffleReadClientImpl readClient =
         baseReadBuilder(isNettyMode)
             .appId(appId)

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerWithKerberizedHadoopTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerWithKerberizedHadoopTest.java
@@ -288,9 +288,9 @@ public class ShuffleServerWithKerberizedHadoopTest extends KerberizedHadoopBase 
         isNettyMode
             ? new ShuffleServerInfo(
                 LOCALHOST,
-                nettyShuffleServers.get(0).getGrpcPort(),
-                nettyShuffleServers.get(0).getNettyPort())
-            : new ShuffleServerInfo(LOCALHOST, grpcShuffleServers.get(0).getGrpcPort());
+                nettyShuffleServer.getGrpcPort(),
+                nettyShuffleServer.getNettyPort())
+            : new ShuffleServerInfo(LOCALHOST, grpcShuffleServer.getGrpcPort());
     ShuffleReadClientImpl readClient =
         baseReadBuilder(isNettyMode)
             .appId(appId)

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerWithKerberizedHadoopTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerWithKerberizedHadoopTest.java
@@ -287,9 +287,7 @@ public class ShuffleServerWithKerberizedHadoopTest extends KerberizedHadoopBase 
     ShuffleServerInfo ssi =
         isNettyMode
             ? new ShuffleServerInfo(
-                LOCALHOST,
-                nettyShuffleServer.getGrpcPort(),
-                nettyShuffleServer.getNettyPort())
+                LOCALHOST, nettyShuffleServer.getGrpcPort(), nettyShuffleServer.getNettyPort())
             : new ShuffleServerInfo(LOCALHOST, grpcShuffleServer.getGrpcPort());
     ShuffleReadClientImpl readClient =
         baseReadBuilder(isNettyMode)

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerWithKerberizedHadoopTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerWithKerberizedHadoopTest.java
@@ -64,8 +64,6 @@ import org.apache.uniffle.server.ShuffleServer;
 import org.apache.uniffle.server.ShuffleServerConf;
 import org.apache.uniffle.storage.util.StorageType;
 
-import static org.apache.uniffle.test.IntegrationTestBase.grpcShuffleServers;
-import static org.apache.uniffle.test.IntegrationTestBase.nettyShuffleServers;
 import static org.apache.uniffle.test.ShuffleReadWriteBase.mockSSI;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerWithLocalOfExceptionTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerWithLocalOfExceptionTest.java
@@ -32,7 +32,6 @@ import org.apache.uniffle.common.rpc.ServerType;
 import org.apache.uniffle.coordinator.CoordinatorConf;
 import org.apache.uniffle.server.ShuffleServerConf;
 import org.apache.uniffle.storage.handler.impl.MemoryClientReadHandler;
-import org.apache.uniffle.storage.util.StorageType;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -45,20 +44,14 @@ public class ShuffleServerWithLocalOfExceptionTest extends ShuffleReadWriteBase 
 
   @BeforeAll
   public static void setupServers(@TempDir File tmpDir) throws Exception {
-    CoordinatorConf coordinatorConf = getCoordinatorConf();
-    createCoordinatorServer(coordinatorConf);
+    CoordinatorConf coordinatorConf = coordinatorConfWithoutPort();
+    storeCoordinatorConf(coordinatorConf);
 
-    ShuffleServerConf shuffleServerConf = getShuffleServerConf(ServerType.GRPC);
-    File dataDir1 = new File(tmpDir, "data1");
-    File dataDir2 = new File(tmpDir, "data2");
-    String basePath = dataDir1.getAbsolutePath() + "," + dataDir2.getAbsolutePath();
-    shuffleServerConf.setString("rss.storage.type", StorageType.LOCALFILE.name());
-    shuffleServerConf.setString("rss.storage.basePath", basePath);
+    ShuffleServerConf shuffleServerConf = shuffleServerConfWithoutPort(0, tmpDir, ServerType.GRPC);
     shuffleServerConf.setString("rss.server.app.expired.withoutHeartbeat", "5000");
-    rpcPort = shuffleServerConf.getInteger(ShuffleServerConf.RPC_SERVER_PORT);
-    createShuffleServer(shuffleServerConf);
+    storeShuffleServerConf(shuffleServerConf);
 
-    startServers();
+    startServersWithRandomPorts();
   }
 
   @BeforeEach

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerWithLocalTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerWithLocalTest.java
@@ -66,38 +66,22 @@ public class ShuffleServerWithLocalTest extends ShuffleReadWriteBase {
 
   private ShuffleServerGrpcClient grpcShuffleServerClient;
   private ShuffleServerGrpcNettyClient nettyShuffleServerClient;
-  private static ShuffleServerConf grpcShuffleServerConfig;
-  private static ShuffleServerConf nettyShuffleServerConfig;
 
   @BeforeAll
   public static void setupServers(@TempDir File tmpDir) throws Exception {
-    CoordinatorConf coordinatorConf = getCoordinatorConf();
-    createCoordinatorServer(coordinatorConf);
+    CoordinatorConf coordinatorConf = coordinatorConfWithoutPort();
+    storeCoordinatorConf(coordinatorConf);
+    storeShuffleServerConf(buildShuffleServerConf(0, tmpDir, ServerType.GRPC));
+    storeShuffleServerConf(buildShuffleServerConf(1, tmpDir, ServerType.GRPC_NETTY));
 
-    File dataDir1 = new File(tmpDir, "data1");
-    File dataDir2 = new File(tmpDir, "data2");
-    String grpcBasePath = dataDir1.getAbsolutePath() + "," + dataDir2.getAbsolutePath();
-    ShuffleServerConf grpcShuffleServerConf = buildShuffleServerConf(ServerType.GRPC, grpcBasePath);
-    createShuffleServer(grpcShuffleServerConf);
-
-    File dataDir3 = new File(tmpDir, "data3");
-    File dataDir4 = new File(tmpDir, "data4");
-    String nettyBasePath = dataDir3.getAbsolutePath() + "," + dataDir4.getAbsolutePath();
-    ShuffleServerConf nettyShuffleServerConf =
-        buildShuffleServerConf(ServerType.GRPC_NETTY, nettyBasePath);
-    createShuffleServer(nettyShuffleServerConf);
-
-    startServers();
-
-    grpcShuffleServerConfig = grpcShuffleServerConf;
-    nettyShuffleServerConfig = nettyShuffleServerConf;
+    startServersWithRandomPorts();
   }
 
-  private static ShuffleServerConf buildShuffleServerConf(ServerType serverType, String basePath)
-      throws Exception {
-    ShuffleServerConf shuffleServerConf = getShuffleServerConf(serverType);
+  private static ShuffleServerConf buildShuffleServerConf(
+      int subDirIndex, File tempDir, ServerType serverType) {
+    ShuffleServerConf shuffleServerConf =
+        shuffleServerConfWithoutPort(subDirIndex, tempDir, serverType);
     shuffleServerConf.setString("rss.storage.type", StorageType.LOCALFILE.name());
-    shuffleServerConf.setString("rss.storage.basePath", basePath);
     shuffleServerConf.setString("rss.server.app.expired.withoutHeartbeat", "5000");
     return shuffleServerConf;
   }
@@ -105,13 +89,12 @@ public class ShuffleServerWithLocalTest extends ShuffleReadWriteBase {
   @BeforeEach
   public void createClient() throws Exception {
     grpcShuffleServerClient =
-        new ShuffleServerGrpcClient(
-            LOCALHOST, grpcShuffleServerConfig.getInteger(ShuffleServerConf.RPC_SERVER_PORT));
+        new ShuffleServerGrpcClient(LOCALHOST, grpcShuffleServers.get(0).getGrpcPort());
     nettyShuffleServerClient =
         new ShuffleServerGrpcNettyClient(
             LOCALHOST,
-            nettyShuffleServerConfig.getInteger(ShuffleServerConf.RPC_SERVER_PORT),
-            nettyShuffleServerConfig.getInteger(ShuffleServerConf.NETTY_SERVER_PORT));
+            nettyShuffleServers.get(0).getGrpcPort(),
+            nettyShuffleServers.get(0).getNettyPort());
   }
 
   @AfterEach


### PR DESCRIPTION
### What changes were proposed in this pull request?
All tests in integration-test/common use random port

### Why are the changes needed?
Fix: #2385

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
UT
