### PR TITLE
[#2389] fix:(remote merge): Fixed the issue of losing data when calling hasNext multiple times.

### DIFF
--- a/client/src/main/java/org/apache/uniffle/client/record/reader/KeyValueReader.java
+++ b/client/src/main/java/org/apache/uniffle/client/record/reader/KeyValueReader.java
@@ -19,11 +19,11 @@ package org.apache.uniffle.client.record.reader;
 
 import java.io.IOException;
 
+import org.apache.uniffle.client.record.Record;
+
 public abstract class KeyValueReader<K, V> {
 
-  public abstract boolean next() throws IOException;
+  public abstract boolean hasNext() throws IOException;
 
-  public abstract K getCurrentKey() throws IOException;
-
-  public abstract V getCurrentValue() throws IOException;
+  public abstract Record<K, V> next() throws IOException;
 }

--- a/client/src/main/java/org/apache/uniffle/client/record/reader/RMRecordsReader.java
+++ b/client/src/main/java/org/apache/uniffle/client/record/reader/RMRecordsReader.java
@@ -269,8 +269,7 @@ public class RMRecordsReader<K, V, C> {
         }
       }
 
-      public Record<ComparativeOutputBuffer, ComparativeOutputBuffer> next()
-          throws IOException {
+      public Record<ComparativeOutputBuffer, ComparativeOutputBuffer> next() throws IOException {
         Record<ComparativeOutputBuffer, ComparativeOutputBuffer> next =
             Record.create(curr.getKey(), curr.getValue());
         curr = null;

--- a/client/src/main/java/org/apache/uniffle/client/record/reader/RMRecordsReader.java
+++ b/client/src/main/java/org/apache/uniffle/client/record/reader/RMRecordsReader.java
@@ -257,8 +257,11 @@ public class RMRecordsReader<K, V, C> {
       private Record<ComparativeOutputBuffer, ComparativeOutputBuffer> curr = null;
 
       @Override
-      public boolean next() throws IOException {
+      public synchronized boolean hasNext() throws IOException {
         try {
+          if (curr != null) {
+            return true;
+          }
           curr = results.take();
           return curr != null;
         } catch (InterruptedException e) {
@@ -266,14 +269,12 @@ public class RMRecordsReader<K, V, C> {
         }
       }
 
-      @Override
-      public ComparativeOutputBuffer getCurrentKey() throws IOException {
-        return curr.getKey();
-      }
-
-      @Override
-      public ComparativeOutputBuffer getCurrentValue() throws IOException {
-        return curr.getValue();
+      public synchronized Record<ComparativeOutputBuffer, ComparativeOutputBuffer> next()
+          throws IOException {
+        Record<ComparativeOutputBuffer, ComparativeOutputBuffer> next =
+            Record.create(curr.getKey(), curr.getValue());
+        curr = null;
+        return next;
       }
     };
   }
@@ -284,8 +285,11 @@ public class RMRecordsReader<K, V, C> {
       private Record<K, C> curr = null;
 
       @Override
-      public boolean next() throws IOException {
+      public synchronized boolean hasNext() throws IOException {
         try {
+          if (curr != null) {
+            return true;
+          }
           curr = results.take();
           return curr != null;
         } catch (InterruptedException e) {
@@ -293,7 +297,12 @@ public class RMRecordsReader<K, V, C> {
         }
       }
 
-      @Override
+      public synchronized Record<K, C> next() throws IOException {
+        Record record = Record.create(getCurrentKey(), getCurrentValue());
+        curr = null;
+        return record;
+      }
+
       public K getCurrentKey() throws IOException {
         if (raw) {
           ComparativeOutputBuffer keyBuffer = (ComparativeOutputBuffer) curr.getKey();
@@ -305,7 +314,6 @@ public class RMRecordsReader<K, V, C> {
         }
       }
 
-      @Override
       public C getCurrentValue() throws IOException {
         if (raw) {
           ComparativeOutputBuffer valueBuffer = (ComparativeOutputBuffer) curr.getValue();

--- a/client/src/main/java/org/apache/uniffle/client/record/reader/RMRecordsReader.java
+++ b/client/src/main/java/org/apache/uniffle/client/record/reader/RMRecordsReader.java
@@ -257,7 +257,7 @@ public class RMRecordsReader<K, V, C> {
       private Record<ComparativeOutputBuffer, ComparativeOutputBuffer> curr = null;
 
       @Override
-      public synchronized boolean hasNext() throws IOException {
+      public boolean hasNext() throws IOException {
         try {
           if (curr != null) {
             return true;
@@ -269,7 +269,7 @@ public class RMRecordsReader<K, V, C> {
         }
       }
 
-      public synchronized Record<ComparativeOutputBuffer, ComparativeOutputBuffer> next()
+      public Record<ComparativeOutputBuffer, ComparativeOutputBuffer> next()
           throws IOException {
         Record<ComparativeOutputBuffer, ComparativeOutputBuffer> next =
             Record.create(curr.getKey(), curr.getValue());
@@ -285,7 +285,7 @@ public class RMRecordsReader<K, V, C> {
       private Record<K, C> curr = null;
 
       @Override
-      public synchronized boolean hasNext() throws IOException {
+      public boolean hasNext() throws IOException {
         try {
           if (curr != null) {
             return true;
@@ -297,7 +297,7 @@ public class RMRecordsReader<K, V, C> {
         }
       }
 
-      public synchronized Record<K, C> next() throws IOException {
+      public Record<K, C> next() throws IOException {
         Record record = Record.create(getCurrentKey(), getCurrentValue());
         curr = null;
         return record;

--- a/client/src/test/java/org/apache/uniffle/client/record/reader/RMRecordsReaderTest.java
+++ b/client/src/test/java/org/apache/uniffle/client/record/reader/RMRecordsReaderTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import org.apache.uniffle.client.api.ShuffleServerClient;
+import org.apache.uniffle.client.record.Record;
 import org.apache.uniffle.client.record.writer.Combiner;
 import org.apache.uniffle.client.record.writer.SumByKeyCombiner;
 import org.apache.uniffle.common.ShuffleServerInfo;
@@ -102,9 +103,10 @@ public class RMRecordsReaderTest {
     readerSpy.start();
     int index = 0;
     KeyValueReader keyValueReader = readerSpy.keyValueReader();
-    while (keyValueReader.next()) {
-      assertEquals(SerializerUtils.genData(keyClass, index), keyValueReader.getCurrentKey());
-      assertEquals(SerializerUtils.genData(valueClass, index), keyValueReader.getCurrentValue());
+    while (keyValueReader.hasNext()) {
+      Record record = keyValueReader.next();
+      assertEquals(SerializerUtils.genData(keyClass, index), record.getKey());
+      assertEquals(SerializerUtils.genData(valueClass, index), record.getValue());
       index++;
     }
     assertEquals(RECORDS_NUM, index);
@@ -172,8 +174,9 @@ public class RMRecordsReaderTest {
     readerSpy.start();
     int index = 0;
     KeyValueReader keyValueReader = readerSpy.keyValueReader();
-    while (keyValueReader.next()) {
-      assertEquals(SerializerUtils.genData(keyClass, index), keyValueReader.getCurrentKey());
+    while (keyValueReader.hasNext()) {
+      Record record = keyValueReader.next();
+      assertEquals(SerializerUtils.genData(keyClass, index), record.getKey());
       Object value = SerializerUtils.genData(valueClass, index);
       Object newValue = value;
       if (index % 2 == 0) {
@@ -183,7 +186,7 @@ public class RMRecordsReaderTest {
           newValue = (int) value * 2;
         }
       }
-      assertEquals(newValue, keyValueReader.getCurrentValue());
+      assertEquals(newValue, record.getValue());
       index++;
     }
     assertEquals(RECORDS_NUM * 2, index);
@@ -250,9 +253,10 @@ public class RMRecordsReaderTest {
     readerSpy.start();
     int index = 0;
     KeyValueReader keyValueReader = readerSpy.keyValueReader();
-    while (keyValueReader.next()) {
-      assertEquals(SerializerUtils.genData(keyClass, index), keyValueReader.getCurrentKey());
-      assertEquals(SerializerUtils.genData(valueClass, index), keyValueReader.getCurrentValue());
+    while (keyValueReader.hasNext()) {
+      Record record = keyValueReader.next();
+      assertEquals(SerializerUtils.genData(keyClass, index), record.getKey());
+      assertEquals(SerializerUtils.genData(valueClass, index), record.getValue());
       index++;
     }
     assertEquals(RECORDS_NUM * 6, index);
@@ -322,10 +326,10 @@ public class RMRecordsReaderTest {
     readerSpy.start();
     int index = 0;
     KeyValueReader keyValueReader = readerSpy.keyValueReader();
-    while (keyValueReader.next()) {
-      assertEquals(SerializerUtils.genData(keyClass, index), keyValueReader.getCurrentKey());
-      assertEquals(
-          SerializerUtils.genData(valueClass, index * 2), keyValueReader.getCurrentValue());
+    while (keyValueReader.hasNext()) {
+      Record record = keyValueReader.next();
+      assertEquals(SerializerUtils.genData(keyClass, index), record.getKey());
+      assertEquals(SerializerUtils.genData(valueClass, index * 2), record.getValue());
       index++;
     }
     assertEquals(RECORDS_NUM * 6, index);

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/RemoteMergeShuffleWithRssClientTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/RemoteMergeShuffleWithRssClientTest.java
@@ -46,6 +46,7 @@ import org.roaringbitmap.longlong.Roaring64NavigableMap;
 
 import org.apache.uniffle.client.factory.ShuffleClientFactory;
 import org.apache.uniffle.client.impl.ShuffleWriteClientImpl;
+import org.apache.uniffle.client.record.Record;
 import org.apache.uniffle.client.record.reader.KeyValueReader;
 import org.apache.uniffle.client.record.reader.RMRecordsReader;
 import org.apache.uniffle.client.record.writer.Combiner;
@@ -309,9 +310,10 @@ public class RemoteMergeShuffleWithRssClientTest extends ShuffleReadWriteBase {
     reader.start();
     int index = 0;
     KeyValueReader keyValueReader = reader.keyValueReader();
-    while (keyValueReader.next()) {
-      assertEquals(SerializerUtils.genData(keyClass, index), keyValueReader.getCurrentKey());
-      assertEquals(SerializerUtils.genData(valueClass, index), keyValueReader.getCurrentValue());
+    while (keyValueReader.hasNext()) {
+      Record record = keyValueReader.next();
+      assertEquals(SerializerUtils.genData(keyClass, index), record.getKey());
+      assertEquals(SerializerUtils.genData(valueClass, index), record.getValue());
       index++;
     }
     assertEquals(5 * RECORD_NUMBER, index);
@@ -479,8 +481,9 @@ public class RemoteMergeShuffleWithRssClientTest extends ShuffleReadWriteBase {
     reader.start();
     int index = 0;
     KeyValueReader keyValueReader = reader.keyValueReader();
-    while (keyValueReader.next()) {
-      assertEquals(SerializerUtils.genData(keyClass, index), keyValueReader.getCurrentKey());
+    while (keyValueReader.hasNext()) {
+      Record record = keyValueReader.next();
+      assertEquals(SerializerUtils.genData(keyClass, index), record.getKey());
       Object value = SerializerUtils.genData(valueClass, index);
       Object newValue = value;
       if (index % 3 != 1) {
@@ -490,7 +493,7 @@ public class RemoteMergeShuffleWithRssClientTest extends ShuffleReadWriteBase {
           newValue = (int) value * 2;
         }
       }
-      assertEquals(newValue, keyValueReader.getCurrentValue());
+      assertEquals(newValue, record.getValue());
       index++;
     }
     assertEquals(3 * RECORD_NUMBER, index);
@@ -697,9 +700,10 @@ public class RemoteMergeShuffleWithRssClientTest extends ShuffleReadWriteBase {
     reader.start();
     int index = 0;
     KeyValueReader keyValueReader = reader.keyValueReader();
-    while (keyValueReader.next()) {
-      assertEquals(SerializerUtils.genData(keyClass, index), keyValueReader.getCurrentKey());
-      assertEquals(SerializerUtils.genData(valueClass, index), keyValueReader.getCurrentValue());
+    while (keyValueReader.hasNext()) {
+      Record record = keyValueReader.next();
+      assertEquals(SerializerUtils.genData(keyClass, index), record.getKey());
+      assertEquals(SerializerUtils.genData(valueClass, index), record.getValue());
       index++;
     }
     assertEquals(6 * RECORD_NUMBER, index);
@@ -910,10 +914,10 @@ public class RemoteMergeShuffleWithRssClientTest extends ShuffleReadWriteBase {
     reader.start();
     int index = 0;
     KeyValueReader keyValueReader = reader.keyValueReader();
-    while (keyValueReader.next()) {
-      assertEquals(SerializerUtils.genData(keyClass, index), keyValueReader.getCurrentKey());
-      assertEquals(
-          SerializerUtils.genData(valueClass, index * 2), keyValueReader.getCurrentValue());
+    while (keyValueReader.hasNext()) {
+      Record record = keyValueReader.next();
+      assertEquals(SerializerUtils.genData(keyClass, index), record.getKey());
+      assertEquals(SerializerUtils.genData(valueClass, index * 2), record.getValue());
       index++;
     }
     assertEquals(6 * RECORD_NUMBER, index);

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/RemoteMergeShuffleWithRssClientTestWhenShuffleFlushed.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/RemoteMergeShuffleWithRssClientTestWhenShuffleFlushed.java
@@ -47,6 +47,7 @@ import org.roaringbitmap.longlong.Roaring64NavigableMap;
 
 import org.apache.uniffle.client.factory.ShuffleClientFactory;
 import org.apache.uniffle.client.impl.ShuffleWriteClientImpl;
+import org.apache.uniffle.client.record.Record;
 import org.apache.uniffle.client.record.reader.KeyValueReader;
 import org.apache.uniffle.client.record.reader.RMRecordsReader;
 import org.apache.uniffle.client.record.writer.Combiner;
@@ -322,9 +323,10 @@ public class RemoteMergeShuffleWithRssClientTestWhenShuffleFlushed extends Shuff
     reader.start();
     int index = 0;
     KeyValueReader keyValueReader = reader.keyValueReader();
-    while (keyValueReader.next()) {
-      assertEquals(SerializerUtils.genData(keyClass, index), keyValueReader.getCurrentKey());
-      assertEquals(SerializerUtils.genData(valueClass, index), keyValueReader.getCurrentValue());
+    while (keyValueReader.hasNext()) {
+      Record record = keyValueReader.next();
+      assertEquals(SerializerUtils.genData(keyClass, index), record.getKey());
+      assertEquals(SerializerUtils.genData(valueClass, index), record.getValue());
       index++;
     }
     assertEquals(5 * RECORD_NUMBER, index);
@@ -493,8 +495,9 @@ public class RemoteMergeShuffleWithRssClientTestWhenShuffleFlushed extends Shuff
     reader.start();
     int index = 0;
     KeyValueReader keyValueReader = reader.keyValueReader();
-    while (keyValueReader.next()) {
-      assertEquals(SerializerUtils.genData(keyClass, index), keyValueReader.getCurrentKey());
+    while (keyValueReader.hasNext()) {
+      Record record = keyValueReader.next();
+      assertEquals(SerializerUtils.genData(keyClass, index), record.getKey());
       Object value = SerializerUtils.genData(valueClass, index);
       Object newValue = value;
       if (index % 3 != 1) {
@@ -504,7 +507,7 @@ public class RemoteMergeShuffleWithRssClientTestWhenShuffleFlushed extends Shuff
           newValue = (int) value * 2;
         }
       }
-      assertEquals(newValue, keyValueReader.getCurrentValue());
+      assertEquals(newValue, record.getValue());
       index++;
     }
     assertEquals(3 * RECORD_NUMBER, index);
@@ -711,9 +714,10 @@ public class RemoteMergeShuffleWithRssClientTestWhenShuffleFlushed extends Shuff
     reader.start();
     int index = 0;
     KeyValueReader keyValueReader = reader.keyValueReader();
-    while (keyValueReader.next()) {
-      assertEquals(SerializerUtils.genData(keyClass, index), keyValueReader.getCurrentKey());
-      assertEquals(SerializerUtils.genData(valueClass, index), keyValueReader.getCurrentValue());
+    while (keyValueReader.hasNext()) {
+      Record record = keyValueReader.next();
+      assertEquals(SerializerUtils.genData(keyClass, index), record.getKey());
+      assertEquals(SerializerUtils.genData(valueClass, index), record.getValue());
       index++;
     }
     assertEquals(6 * RECORD_NUMBER, index);
@@ -925,10 +929,10 @@ public class RemoteMergeShuffleWithRssClientTestWhenShuffleFlushed extends Shuff
     reader.start();
     int index = 0;
     KeyValueReader keyValueReader = reader.keyValueReader();
-    while (keyValueReader.next()) {
-      assertEquals(SerializerUtils.genData(keyClass, index), keyValueReader.getCurrentKey());
-      assertEquals(
-          SerializerUtils.genData(valueClass, index * 2), keyValueReader.getCurrentValue());
+    while (keyValueReader.hasNext()) {
+      Record record = keyValueReader.next();
+      assertEquals(SerializerUtils.genData(keyClass, index), record.getKey());
+      assertEquals(SerializerUtils.genData(valueClass, index * 2), record.getValue());
       index++;
     }
     assertEquals(6 * RECORD_NUMBER, index);


### PR DESCRIPTION
### What changes were proposed in this pull request?

KeyValueReader::next combines the semantics of hasNext and next, which is unreasonable and should be separated.

### Why are the changes needed?

Fix: #2389 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

unit test and integration test
