### PR TITLE
[#2398]Improvement: Fix the warning unchecked generic array creation for varargs parameter of type `Class<? extends Throwable>[]`

### DIFF
--- a/common/src/test/java/org/apache/uniffle/common/KerberizedHadoop.java
+++ b/common/src/test/java/org/apache/uniffle/common/KerberizedHadoop.java
@@ -32,8 +32,10 @@ import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
-import com.google.common.collect.Sets;
 import org.apache.commons.lang3.JavaVersion;
 import org.apache.commons.lang3.SystemUtils;
 import org.apache.hadoop.conf.Configuration;
@@ -190,6 +192,9 @@ public class KerberizedHadoop implements Serializable {
     hdfsConf.set("hadoop.proxyuser.hdfs.groups", "*");
     hdfsConf.set("hadoop.proxyuser.hdfs.users", "*");
 
+    Set<Class<? extends Throwable>> retrySet =
+        Stream.of(BindException.class).collect(Collectors.toSet());
+
     this.kerberizedDfsCluster =
         RetryUtils.retry(
             () -> {
@@ -217,7 +222,7 @@ public class KerberizedHadoop implements Serializable {
             },
             1000L,
             5,
-            Sets.newHashSet(BindException.class));
+            retrySet);
   }
 
   private void startKDC() throws Exception {

--- a/common/src/test/java/org/apache/uniffle/common/util/RetryUtilsTest.java
+++ b/common/src/test/java/org/apache/uniffle/common/util/RetryUtilsTest.java
@@ -17,9 +17,11 @@
 
 package org.apache.uniffle.common.util;
 
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
-import com.google.common.collect.Sets;
 import org.junit.jupiter.api.Test;
 
 import org.apache.uniffle.common.exception.NotRetryException;
@@ -27,10 +29,10 @@ import org.apache.uniffle.common.exception.RssException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class RetryUtilsTest {
+class RetryUtilsTest {
 
   @Test
-  public void testRetryWithCondition() {
+  void testRetryWithCondition() {
     AtomicInteger tryTimes = new AtomicInteger();
     AtomicInteger callbackTime = new AtomicInteger();
     try {
@@ -54,11 +56,13 @@ public class RetryUtilsTest {
   }
 
   @Test
-  public void testRetry() {
+  void testRetry() {
     AtomicInteger tryTimes = new AtomicInteger();
     AtomicInteger callbackTime = new AtomicInteger();
     int maxTryTime = 3;
     try {
+      Set<Class<? extends Throwable>> retrySet =
+          Stream.of(RssException.class).collect(Collectors.toSet());
       RetryUtils.retry(
           () -> {
             tryTimes.incrementAndGet();
@@ -69,7 +73,7 @@ public class RetryUtilsTest {
           },
           10,
           maxTryTime,
-          Sets.newHashSet(RssException.class));
+          retrySet);
     } catch (Throwable throwable) {
       // ignore
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix the warning unchecked generic array creation for varargs parameter of type `Class<? extends Throwable>[]`

### Why are the changes needed?
Fix: #2398

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
![image](https://github.com/user-attachments/assets/bccf2241-01a7-4259-a473-e76287ccf1c7)

