### PR TITLE
[#2401] Make it possible to get the actual port when config jetty port to zero

### DIFF
--- a/common/src/main/java/org/apache/uniffle/common/web/JettyServer.java
+++ b/common/src/main/java/org/apache/uniffle/common/web/JettyServer.java
@@ -169,13 +169,15 @@ public class JettyServer {
     return this.server;
   }
 
-  public void start() throws Exception {
+  public int start() throws Exception {
     try {
       server.start();
+      httpPort = ((ServerConnector) server.getConnectors()[0]).getLocalPort();
     } catch (BindException e) {
       ExitUtils.terminate(1, "Fail to start jetty http server, port is " + httpPort, e, LOG);
     }
     LOG.info("Jetty http server started, listening on port {}", httpPort);
+    return httpPort;
   }
 
   public void stop() throws Exception {

--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/CoordinatorServer.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/CoordinatorServer.java
@@ -63,6 +63,7 @@ public class CoordinatorServer {
   private final CoordinatorConf coordinatorConf;
   private final long startTimeMs;
   private JettyServer jettyServer;
+  private int jettyPort;
   private ServerInterface server;
   private ClusterManager clusterManager;
   private AssignmentStrategy assignmentStrategy;
@@ -106,7 +107,7 @@ public class CoordinatorServer {
   public void start() throws Exception {
     LOG.info(
         "{} version: {}", this.getClass().getSimpleName(), Constants.VERSION_AND_REVISION_SHORT);
-    jettyServer.start();
+    jettyPort = jettyServer.start();
     rpcListenPort = server.start();
     if (metricReporter != null) {
       metricReporter.start();
@@ -284,5 +285,9 @@ public class CoordinatorServer {
 
   public int getRpcListenPort() {
     return rpcListenPort;
+  }
+
+  public int getJettyPort() {
+    return jettyPort;
   }
 }

--- a/coordinator/src/test/java/org/apache/uniffle/coordinator/CoordinatorServerTest.java
+++ b/coordinator/src/test/java/org/apache/uniffle/coordinator/CoordinatorServerTest.java
@@ -31,11 +31,11 @@ public class CoordinatorServerTest {
   public void test() throws Exception {
     CoordinatorConf coordinatorConf = new CoordinatorConf();
     coordinatorConf.setInteger("rss.rpc.server.port", 9537);
-    coordinatorConf.setInteger("rss.jetty.http.port", 9528);
+    coordinatorConf.setInteger("rss.jetty.http.port", 0);
     coordinatorConf.setInteger("rss.rpc.executor.size", 10);
 
     CoordinatorServer cs1 = new CoordinatorServer(coordinatorConf);
-    CoordinatorServer cs2 = new CoordinatorServer(coordinatorConf);
+    CoordinatorServer cs2 = null;
     CoordinatorServer cs3 = null;
     try {
       cs1.start();
@@ -44,6 +44,8 @@ public class CoordinatorServerTest {
       String expectMessage = "Fail to start jetty http server";
       final int expectStatus = 1;
       try {
+        coordinatorConf.setInteger("rss.jetty.http.port", cs1.getJettyPort());
+        cs2 = new CoordinatorServer(coordinatorConf);
         cs2.start();
       } catch (Exception e) {
         assertTrue(e.getMessage().startsWith(expectMessage));
@@ -53,7 +55,7 @@ public class CoordinatorServerTest {
         cs2.stopServer();
       }
 
-      coordinatorConf.setInteger("rss.jetty.http.port", 9529);
+      coordinatorConf.setInteger("rss.jetty.http.port", 0);
       cs3 = new CoordinatorServer(coordinatorConf);
       expectMessage = "Fail to start grpc server";
       try {

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServer.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServer.java
@@ -98,6 +98,7 @@ public class ShuffleServer {
   private int nettyPort;
   private ShuffleServerConf shuffleServerConf;
   private JettyServer jettyServer;
+  private int jettyPort;
   private ShuffleTaskManager shuffleTaskManager;
   private ServerInterface server;
   private ShuffleFlushManager shuffleFlushManager;
@@ -152,7 +153,7 @@ public class ShuffleServer {
   public void start() throws Exception {
     LOG.info(
         "{} version: {}", this.getClass().getSimpleName(), Constants.VERSION_AND_REVISION_SHORT);
-    jettyServer.start();
+    jettyPort = jettyServer.start();
     grpcPort = server.start();
     if (nettyServerEnabled) {
       nettyPort = streamServer.start();
@@ -578,7 +579,7 @@ public class ShuffleServer {
   }
 
   public int getJettyPort() {
-    return jettyServer.getHttpPort();
+    return jettyPort;
   }
 
   public String getEncodedTags() {

--- a/server/src/test/java/org/apache/uniffle/server/ShuffleServerTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/ShuffleServerTest.java
@@ -61,7 +61,7 @@ public class ShuffleServerTest {
       assertEquals(expectStatus, ((ExitException) e).getStatus());
     }
 
-    serverConf.setInteger("rss.jetty.http.port", 9529);
+    serverConf.setInteger("rss.jetty.http.port", 0);
     ss2 = new ShuffleServer(serverConf);
     expectMessage = "Fail to start grpc server";
     try {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Make it possible to get the actual port when config jetty port to zero

### Why are the changes needed?
Support jetty use random port
Fix: #2401 

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
UT
