### PR TITLE
[#2385] fix(server): FileSegmentManagedBuffer release concurrently avoid NPE

### DIFF
--- a/common/src/main/java/org/apache/uniffle/common/netty/buffer/FileSegmentManagedBuffer.java
+++ b/common/src/main/java/org/apache/uniffle/common/netty/buffer/FileSegmentManagedBuffer.java
@@ -108,7 +108,6 @@ public class FileSegmentManagedBuffer extends ManagedBuffer {
 
   @Override
   public ManagedBuffer release() {
-    cachedBuffer.clear();
     cachedBuffer = null;
     isFilled = false;
     return this;


### PR DESCRIPTION
### What changes were proposed in this pull request?
Avoid release cachedBuffer, when FileSegmentManagedBuffer release

### Why are the changes needed?
There is no need to invoke release, since the reference of cachedBuffer is reset, besides this may cause concurrent issue
Fix #2404 


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
UT
