### PR TITLE
feat(client): No need to re-register for those servers being excluded

### DIFF
--- a/client-spark/common/src/main/java/org/apache/uniffle/shuffle/manager/RssShuffleManagerBase.java
+++ b/client-spark/common/src/main/java/org/apache/uniffle/shuffle/manager/RssShuffleManagerBase.java
@@ -1019,8 +1019,6 @@ public abstract class RssShuffleManagerBase implements RssShuffleManagerInterfac
           StatusCode code = receivingFailureServer.getStatusCode();
           String serverId = receivingFailureServer.getServerId();
 
-          boolean serverHasReplaced = false;
-
           Set<ShuffleServerInfo> updatedReassignServers;
           if (!partitionSplit) {
             Set<ShuffleServerInfo> replacements = internalHandle.getReplacements(serverId);
@@ -1033,8 +1031,6 @@ public abstract class RssShuffleManagerBase implements RssShuffleManagerInterfac
                       internalHandle,
                       partitionId,
                       serverId);
-            } else {
-              serverHasReplaced = true;
             }
             updatedReassignServers =
                 internalHandle.updateAssignment(partitionId, serverId, replacements);
@@ -1050,8 +1046,6 @@ public abstract class RssShuffleManagerBase implements RssShuffleManagerInterfac
                       internalHandle,
                       partitionId,
                       serverId);
-            } else {
-              serverHasReplaced = true;
             }
             updatedReassignServers =
                 internalHandle.updateAssignmentOnPartitionSplit(
@@ -1066,23 +1060,8 @@ public abstract class RssShuffleManagerBase implements RssShuffleManagerInterfac
                     updatedReassignServers.stream()
                         .map(x -> x.getId())
                         .collect(Collectors.toSet()));
-
-            if (serverHasReplaced) {
-              for (ShuffleServerInfo serverInfo : updatedReassignServers) {
-                newServerToPartitions
-                    .computeIfAbsent(serverInfo, x -> new ArrayList<>())
-                    .add(new PartitionRange(partitionId, partitionId));
-              }
-            }
           }
         }
-      }
-      if (!newServerToPartitions.isEmpty()) {
-        LOG.info(
-            "Register the new partition->servers assignment on reassign. {}",
-            newServerToPartitions);
-        registerShuffleServers(
-            getAppId(), shuffleId, newServerToPartitions, getRemoteStorageInfo());
       }
 
       LOG.info(


### PR DESCRIPTION
### What changes were proposed in this pull request?

No need to re-register for those servers being excluded

### Why are the changes needed?

To speed up reassign rpc

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing reassignment tests 