### PR TITLE
feat(client): Introduce `LOAD_BALANCE` mode for partition split

### DIFF
--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/handle/ShuffleHandleInfo.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/handle/ShuffleHandleInfo.java
@@ -21,6 +21,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.spark.shuffle.handle.split.PartitionSplitInfo;
+
 import org.apache.uniffle.client.PartitionDataReplicaRequirementTracking;
 import org.apache.uniffle.common.RemoteStorageInfo;
 import org.apache.uniffle.common.ShuffleServerInfo;
@@ -48,4 +50,6 @@ public interface ShuffleHandleInfo {
   int getShuffleId();
 
   RemoteStorageInfo getRemoteStorage();
+
+  PartitionSplitInfo getPartitionSplitInfo(int partitionId);
 }

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/handle/SimpleShuffleHandleInfo.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/handle/SimpleShuffleHandleInfo.java
@@ -23,6 +23,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.apache.spark.shuffle.handle.split.PartitionSplitInfo;
+
 import org.apache.uniffle.client.PartitionDataReplicaRequirementTracking;
 import org.apache.uniffle.common.RemoteStorageInfo;
 import org.apache.uniffle.common.ShuffleServerInfo;
@@ -68,6 +70,11 @@ public class SimpleShuffleHandleInfo extends ShuffleHandleInfoBase implements Se
 
   public RemoteStorageInfo getRemoteStorage() {
     return remoteStorage;
+  }
+
+  @Override
+  public PartitionSplitInfo getPartitionSplitInfo(int partitionId) {
+    return null;
   }
 
   public int getShuffleId() {

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/handle/StageAttemptShuffleHandleInfo.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/handle/StageAttemptShuffleHandleInfo.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.Set;
 
 import com.google.common.collect.Lists;
+import org.apache.spark.shuffle.handle.split.PartitionSplitInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -74,6 +75,11 @@ public class StageAttemptShuffleHandleInfo extends ShuffleHandleInfoBase {
   @Override
   public PartitionDataReplicaRequirementTracking createPartitionReplicaTracking() {
     return current.createPartitionReplicaTracking();
+  }
+
+  @Override
+  public PartitionSplitInfo getPartitionSplitInfo(int partitionId) {
+    return current.getPartitionSplitInfo(partitionId);
   }
 
   /**

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/handle/split/PartitionSplitInfo.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/handle/split/PartitionSplitInfo.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.shuffle.handle.split;
+
+import java.util.List;
+
+import org.apache.uniffle.common.PartitionSplitMode;
+import org.apache.uniffle.common.ShuffleServerInfo;
+
+public class PartitionSplitInfo {
+  private int partitionId;
+  private boolean isSplit;
+  private PartitionSplitMode mode;
+
+  // first list's index is the replica index
+  // nested list is the all assigned shuffle-servers
+  private List<List<ShuffleServerInfo>> splitServers;
+
+  public PartitionSplitInfo(
+      int partitionId,
+      boolean isSplit,
+      PartitionSplitMode mode,
+      List<List<ShuffleServerInfo>> splitServers) {
+    this.partitionId = partitionId;
+    this.isSplit = isSplit;
+    this.mode = mode;
+    this.splitServers = splitServers;
+  }
+
+  public int getPartitionId() {
+    return partitionId;
+  }
+
+  public boolean isSplit() {
+    return isSplit;
+  }
+
+  public PartitionSplitMode getMode() {
+    return mode;
+  }
+
+  public List<List<ShuffleServerInfo>> getSplitServers() {
+    return splitServers;
+  }
+}

--- a/client-spark/common/src/main/java/org/apache/uniffle/shuffle/manager/RssShuffleManagerBase.java
+++ b/client-spark/common/src/main/java/org/apache/uniffle/shuffle/manager/RssShuffleManagerBase.java
@@ -82,6 +82,7 @@ import org.apache.uniffle.client.response.RssReassignOnStageRetryResponse;
 import org.apache.uniffle.client.util.ClientUtils;
 import org.apache.uniffle.common.ClientType;
 import org.apache.uniffle.common.PartitionRange;
+import org.apache.uniffle.common.PartitionSplitMode;
 import org.apache.uniffle.common.ReceivingFailureServer;
 import org.apache.uniffle.common.RemoteStorageInfo;
 import org.apache.uniffle.common.ShuffleAssignmentsInfo;
@@ -168,6 +169,10 @@ public abstract class RssShuffleManagerBase implements RssShuffleManagerInterfac
   private ShuffleManagerGrpcService service;
   protected GrpcServer shuffleManagerServer;
   protected DataPusher dataPusher;
+
+  // Only valid on reassign activation
+  private int partitionSplitLoadBalanceServerNum;
+  protected PartitionSplitMode partitionSplitMode;
 
   public RssShuffleManagerBase(SparkConf conf, boolean isDriver) {
     LOG.info(
@@ -271,6 +276,9 @@ public abstract class RssShuffleManagerBase implements RssShuffleManagerInterfac
         throw new RssException(
             "The feature of task partition reassign is incompatible with multiple replicas mechanism.");
       }
+      this.partitionSplitMode = rssConf.get(RssClientConf.RSS_CLIENT_PARTITION_SPLIT_MODE);
+      this.partitionSplitLoadBalanceServerNum =
+          rssConf.get(RssClientConf.RSS_CLIENT_PARTITION_SPLIT_LOAD_BALANCE_SERVER_NUMBER);
       LOG.info("Partition reassign is enabled.");
     }
     this.blockIdSelfManagedEnabled = rssConf.getBoolean(RSS_BLOCK_ID_SELF_MANAGEMENT_ENABLED);
@@ -968,7 +976,8 @@ public abstract class RssShuffleManagerBase implements RssShuffleManagerInterfac
             stageAttemptNumber,
             false);
     MutableShuffleHandleInfo shuffleHandleInfo =
-        new MutableShuffleHandleInfo(shuffleId, partitionToServers, getRemoteStorageInfo());
+        new MutableShuffleHandleInfo(
+            shuffleId, partitionToServers, getRemoteStorageInfo(), partitionSplitMode);
     StageAttemptShuffleHandleInfo stageAttemptShuffleHandleInfo =
         (StageAttemptShuffleHandleInfo) shuffleHandleInfoManager.get(shuffleId);
     stageAttemptShuffleHandleInfo.replaceCurrentShuffleHandleInfo(shuffleHandleInfo);
@@ -1040,6 +1049,13 @@ public abstract class RssShuffleManagerBase implements RssShuffleManagerInterfac
             updatedReassignServers =
                 internalHandle.updateAssignment(partitionId, serverId, replacements);
           } else {
+            // todo: must ensure in the load_balance mode, the same partition will not trigger multi
+            // reassignments.
+            int requireServerNum = 1;
+            if (partitionSplitMode == PartitionSplitMode.LOAD_BALANCE) {
+              requireServerNum = partitionSplitLoadBalanceServerNum;
+            }
+
             Set<ShuffleServerInfo> replacements =
                 internalHandle.getReplacementsForPartition(partitionId, serverId);
             if (CollectionUtils.isEmpty(replacements)) {
@@ -1050,7 +1066,8 @@ public abstract class RssShuffleManagerBase implements RssShuffleManagerInterfac
                       shuffleId,
                       internalHandle,
                       partitionId,
-                      serverId);
+                      serverId,
+                      requireServerNum);
             } else {
               serverHasReplaced = true;
             }
@@ -1087,8 +1104,9 @@ public abstract class RssShuffleManagerBase implements RssShuffleManagerInterfac
       }
 
       LOG.info(
-          "Finished reassignOnBlockSendFailure request and cost {}(ms). Reassign result: {}",
+          "Finished reassignOnBlockSendFailure request and cost {}(ms). is partition split:{}. Reassign result: {}",
           System.currentTimeMillis() - startTime,
+          partitionSplit,
           reassignResult);
 
       return internalHandle;
@@ -1101,9 +1119,9 @@ public abstract class RssShuffleManagerBase implements RssShuffleManagerInterfac
       int shuffleId,
       MutableShuffleHandleInfo internalHandle,
       int partitionId,
-      String serverId) {
+      String serverId,
+      int requiredServerNum) {
     Set<ShuffleServerInfo> replacements;
-    final int requiredServerNum = 1;
     Set<String> excludedServers = new HashSet<>(internalHandle.listExcludedServers());
     // Exclude the servers that has already been replaced for partition split case.
     excludedServers.addAll(internalHandle.listExcludedServersForPartition(partitionId));
@@ -1118,6 +1136,17 @@ public abstract class RssShuffleManagerBase implements RssShuffleManagerInterfac
             requiredServerNum,
             true);
     return replacements;
+  }
+
+  private Set<ShuffleServerInfo> requestReassignServer(
+      int stageId,
+      int stageAttemptNumber,
+      int shuffleId,
+      MutableShuffleHandleInfo internalHandle,
+      int partitionId,
+      String serverId) {
+    return this.requestReassignServer(
+        stageId, stageAttemptNumber, shuffleId, internalHandle, partitionId, serverId, 1);
   }
 
   @Override

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -179,13 +179,15 @@ public class RssShuffleManager extends RssShuffleManagerBase {
     shuffleIdToNumMapTasks.putIfAbsent(shuffleId, dependency.rdd().partitions().length);
     if (shuffleManagerRpcServiceEnabled && rssStageRetryForWriteFailureEnabled) {
       ShuffleHandleInfo shuffleHandleInfo =
-          new MutableShuffleHandleInfo(shuffleId, partitionToServers, remoteStorage);
+          new MutableShuffleHandleInfo(
+              shuffleId, partitionToServers, remoteStorage, partitionSplitMode);
       StageAttemptShuffleHandleInfo handleInfo =
           new StageAttemptShuffleHandleInfo(shuffleId, remoteStorage, shuffleHandleInfo);
       shuffleHandleInfoManager.register(shuffleId, handleInfo);
     } else if (shuffleManagerRpcServiceEnabled && partitionReassignEnabled) {
       ShuffleHandleInfo shuffleHandleInfo =
-          new MutableShuffleHandleInfo(shuffleId, partitionToServers, remoteStorage);
+          new MutableShuffleHandleInfo(
+              shuffleId, partitionToServers, remoteStorage, partitionSplitMode);
       shuffleHandleInfoManager.register(shuffleId, shuffleHandleInfo);
     }
     Broadcast<SimpleShuffleHandleInfo> hdlInfoBd =

--- a/common/src/main/java/org/apache/uniffle/common/PartitionSplitMode.java
+++ b/common/src/main/java/org/apache/uniffle/common/PartitionSplitMode.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.uniffle.common;
+
+public enum PartitionSplitMode {
+  LOAD_BALANCE,
+  PIPELINE,
+}

--- a/common/src/main/java/org/apache/uniffle/common/PartitionSplitMode.java
+++ b/common/src/main/java/org/apache/uniffle/common/PartitionSplitMode.java
@@ -17,7 +17,10 @@
 
 package org.apache.uniffle.common;
 
+/** The partition split mode for the partition split mechanism */
 public enum PartitionSplitMode {
+  // Reassign multi servers for one time to write for load balance
   LOAD_BALANCE,
+  // Reassign server one by one once partition split
   PIPELINE,
 }

--- a/common/src/main/java/org/apache/uniffle/common/config/RssClientConf.java
+++ b/common/src/main/java/org/apache/uniffle/common/config/RssClientConf.java
@@ -20,6 +20,7 @@ package org.apache.uniffle.common.config;
 import java.util.List;
 
 import org.apache.uniffle.common.ClientType;
+import org.apache.uniffle.common.PartitionSplitMode;
 import org.apache.uniffle.common.ShuffleDataDistributionType;
 import org.apache.uniffle.common.compression.Codec;
 import org.apache.uniffle.common.netty.IOMode;
@@ -270,6 +271,19 @@ public class RssClientConf {
           .defaultValue(false)
           .withDescription(
               "Whether to support rss client block send failure retry, default value is false.");
+
+  public static final ConfigOption<PartitionSplitMode> RSS_CLIENT_PARTITION_SPLIT_MODE =
+      ConfigOptions.key("rss.client.reassign.partitionSplitMode")
+          .enumType(PartitionSplitMode.class)
+          .defaultValue(PartitionSplitMode.PIPELINE)
+          .withDescription("The partition split mode. default is PIPELINE.");
+
+  public static final ConfigOption<Integer> RSS_CLIENT_PARTITION_SPLIT_LOAD_BALANCE_SERVER_NUMBER =
+      ConfigOptions.key("rss.client.reassign.partitionSplitLoadBalanceServerNumber")
+          .intType()
+          .defaultValue(10)
+          .withDescription(
+              "The partition split load balance server number. Only valid for load balance split mode.");
 
   public static final ConfigOption<Integer> RSS_CLIENT_REMOTE_MERGE_FETCH_INIT_SLEEP_MS =
       ConfigOptions.key("rss.client.remote.merge.fetch.initSleepMs")

--- a/integration-test/spark-common/src/test/java/org/apache/uniffle/test/SparkIntegrationTestBase.java
+++ b/integration-test/spark-common/src/test/java/org/apache/uniffle/test/SparkIntegrationTestBase.java
@@ -101,8 +101,13 @@ public abstract class SparkIntegrationTestBase extends IntegrationTestBase {
     }
     spark = SparkSession.builder().config(sparkConf).getOrCreate();
     Map result = runTest(spark, testFileName);
+    checkRunState(sparkConf);
     spark.stop();
     return result;
+  }
+
+  protected void checkRunState(SparkConf sparkConf) {
+    // ignore
   }
 
   protected SparkConf createSparkConf() {

--- a/integration-test/spark3/src/test/java/org/apache/uniffle/test/PartitionSplitOfLoadBalanceModeTest.java
+++ b/integration-test/spark3/src/test/java/org/apache/uniffle/test/PartitionSplitOfLoadBalanceModeTest.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.uniffle.test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import com.google.common.collect.Maps;
+import org.apache.spark.SparkConf;
+import org.apache.spark.shuffle.RssSparkConfig;
+import org.junit.jupiter.api.BeforeAll;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.uniffle.common.PartitionSplitMode;
+import org.apache.uniffle.common.rpc.ServerType;
+import org.apache.uniffle.coordinator.CoordinatorConf;
+import org.apache.uniffle.server.ShuffleServerConf;
+import org.apache.uniffle.storage.util.StorageType;
+
+import static org.apache.uniffle.client.util.RssClientConfig.RSS_CLIENT_ASSIGNMENT_SHUFFLE_SERVER_NUMBER;
+import static org.apache.uniffle.client.util.RssClientConfig.RSS_CLIENT_RETRY_MAX;
+import static org.apache.uniffle.common.config.RssClientConf.RSS_CLIENT_PARTITION_SPLIT_LOAD_BALANCE_SERVER_NUMBER;
+import static org.apache.uniffle.common.config.RssClientConf.RSS_CLIENT_PARTITION_SPLIT_MODE;
+import static org.apache.uniffle.common.config.RssClientConf.RSS_CLIENT_REASSIGN_ENABLED;
+
+/** This class is to simulate test partition split on load balance mode. */
+public class PartitionSplitOfLoadBalanceModeTest extends SparkSQLTest {
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(PartitionSplitOfLoadBalanceModeTest.class);
+
+  @BeforeAll
+  public static void setupServers() throws Exception {
+    LOGGER.info("Setup servers");
+
+    // for coordinator
+    CoordinatorConf coordinatorConf = coordinatorConfWithoutPort();
+    coordinatorConf.setLong("rss.coordinator.app.expired", 5000);
+    Map<String, String> dynamicConf = Maps.newHashMap();
+    dynamicConf.put(RssSparkConfig.RSS_STORAGE_TYPE.key(), StorageType.MEMORY_LOCALFILE.name());
+    addDynamicConf(coordinatorConf, dynamicConf);
+    storeCoordinatorConf(coordinatorConf);
+
+    // starting 3 nodes with grpc
+    for (int i = 0; i < 3; i++) {
+      storeShuffleServerConf(buildShuffleServerConf(ServerType.GRPC, i));
+    }
+    // starting 3 nodes with grpc-netty
+    for (int i = 0; i < 3; i++) {
+      storeShuffleServerConf(buildShuffleServerConf(ServerType.GRPC_NETTY, i));
+    }
+    startServersWithRandomPorts();
+  }
+
+  private static ShuffleServerConf buildShuffleServerConf(ServerType serverType, int index)
+      throws IOException {
+    Path tempDir = Files.createTempDirectory(serverType + "-" + index);
+    String dataPath = tempDir.toAbsolutePath().toString();
+
+    ShuffleServerConf shuffleServerConf = shuffleServerConfWithoutPort(0, null, serverType);
+    shuffleServerConf.setLong("rss.server.heartbeat.interval", 5000);
+    shuffleServerConf.setLong("rss.server.app.expired.withoutHeartbeat", 4000);
+    shuffleServerConf.setString("rss.storage.basePath", dataPath);
+    shuffleServerConf.setString("rss.storage.type", StorageType.MEMORY_LOCALFILE.name());
+    shuffleServerConf.setString("rss.server.huge-partition.split.limit", "-1");
+    return shuffleServerConf;
+  }
+
+  @Override
+  public void updateSparkConfCustomer(SparkConf sparkConf) {
+    sparkConf.set("spark.sql.shuffle.partitions", "4");
+
+    sparkConf.set("spark." + RSS_CLIENT_RETRY_MAX, "1");
+    sparkConf.set("spark." + RSS_CLIENT_ASSIGNMENT_SHUFFLE_SERVER_NUMBER, "1");
+    sparkConf.set("spark." + RSS_CLIENT_REASSIGN_ENABLED.key(), "true");
+    sparkConf.set(
+        "spark." + RSS_CLIENT_PARTITION_SPLIT_MODE, PartitionSplitMode.LOAD_BALANCE.name());
+    sparkConf.set("spark." + RSS_CLIENT_PARTITION_SPLIT_LOAD_BALANCE_SERVER_NUMBER, "2");
+  }
+
+  @Override
+  public void updateRssStorage(SparkConf sparkConf) {
+    // ignore
+  }
+
+  @Override
+  public void checkShuffleData() throws Exception {
+    // ignore
+  }
+}

--- a/integration-test/spark3/src/test/java/org/apache/uniffle/test/PartitionSplitOfLoadBalanceModeTest.java
+++ b/integration-test/spark3/src/test/java/org/apache/uniffle/test/PartitionSplitOfLoadBalanceModeTest.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import com.google.common.collect.Maps;
 import org.apache.spark.SparkConf;
 import org.apache.spark.shuffle.RssSparkConfig;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,7 +43,6 @@ import static org.apache.uniffle.client.util.RssClientConfig.RSS_CLIENT_RETRY_MA
 import static org.apache.uniffle.common.config.RssClientConf.RSS_CLIENT_PARTITION_SPLIT_LOAD_BALANCE_SERVER_NUMBER;
 import static org.apache.uniffle.common.config.RssClientConf.RSS_CLIENT_PARTITION_SPLIT_MODE;
 import static org.apache.uniffle.common.config.RssClientConf.RSS_CLIENT_REASSIGN_ENABLED;
-import static org.junit.Assert.assertEquals;
 
 /** This class is to simulate test partition split on load balance mode. */
 public class PartitionSplitOfLoadBalanceModeTest extends SparkSQLTest {
@@ -107,11 +107,11 @@ public class PartitionSplitOfLoadBalanceModeTest extends SparkSQLTest {
       // All servers will be assigned for one app due to the partition split
       if (sparkConf.get(RSS_CLIENT_TYPE).equals("GRPC")) {
         for (ShuffleServer shuffleServer : grpcShuffleServers) {
-          assertEquals(1, shuffleServer.getAppInfos().size());
+          Assertions.assertEquals(1, shuffleServer.getAppInfos().size());
         }
       } else {
         for (ShuffleServer shuffleServer : nettyShuffleServers) {
-          assertEquals(1, shuffleServer.getAppInfos().size());
+          Assertions.assertEquals(1, shuffleServer.getAppInfos().size());
         }
       }
     }

--- a/proto/src/main/proto/Rss.proto
+++ b/proto/src/main/proto/Rss.proto
@@ -626,6 +626,19 @@ message MutableShuffleHandleInfo {
   int32 shuffleId = 1;
   map<int32, PartitionReplicaServers> partitionToServers = 2;
   RemoteStorageInfo remoteStorageInfo = 3;
+
+  map<string, ReplacementServers> excludedServerToReplacements = 4;
+  repeated int32 splitPartitionId = 5;
+  PartitionSplitMode partitionSplitMode = 6;
+}
+
+enum PartitionSplitMode {
+  PIPELINE = 0;
+  LOAD_BALANCE = 1;
+}
+
+message ReplacementServers {
+  repeated ShuffleServerId serverId = 1;
 }
 
 message PartitionReplicaServers {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Introduce the load_balance mode for partition split

### Why are the changes needed?

Firstly, thanks the great work to @maobaolong . This work is based on the #2093, this introduces the load_balance mode for the partition split.

As we know, if the partition is big, the partition split will be activated to reassign to another server. For the default impl, the reassign logic is pipeline. it will reassign for first server -> second -> third until reaching the max reassignment server num limit.

But for the huge partition with huge write throughput at the same time, I hope this can write the multi servers for load balance to speed up writing.

### Does this PR introduce _any_ user-facing change?

Yes. 
1. `rss.client.reassign.partitionSplitMode`. Default value PIPELINE (that is consistent with previous codebase)
2. `rss.client.reassign.partitionSplitLoadBalanceServerNumber` . Default value is 10. Only valid for load balance mode.

### How was this patch tested?

1. Internal spark jobs tests
