### PR TITLE
[MINOR] fix(test): Fix test for LocalStorageManagerTest

### DIFF
--- a/storage/src/main/java/org/apache/uniffle/storage/common/DefaultStorageMediaProvider.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/common/DefaultStorageMediaProvider.java
@@ -102,9 +102,12 @@ public class DefaultStorageMediaProvider implements StorageMediaProvider {
 
   @VisibleForTesting
   static String getDeviceName(String mountPoint) {
-    // mountPoint would be /dev/sda1, /dev/vda1, rootfs, etc.
+    // mountPoint would be /dev/sda1, /dev/vda1, /dev/nvme0n1p6, rootfs, etc.
     int separatorIndex = mountPoint.lastIndexOf(File.separator);
     String deviceName = separatorIndex > -1 ? mountPoint.substring(separatorIndex + 1) : mountPoint;
+    if (deviceName.startsWith("nvme") && deviceName.contains("p")) {
+      return deviceName.substring(0, deviceName.lastIndexOf("p"));
+    }
     return StringUtils.stripEnd(deviceName, NUMBERIC_STRING);
   }
 }

--- a/storage/src/test/java/org/apache/uniffle/storage/common/DefaultStorageMediaProviderTest.java
+++ b/storage/src/test/java/org/apache/uniffle/storage/common/DefaultStorageMediaProviderTest.java
@@ -52,6 +52,7 @@ public class DefaultStorageMediaProviderTest {
     assertEquals("rootfs", DefaultStorageMediaProvider.getDeviceName("rootfs"));
     assertEquals("sda", DefaultStorageMediaProvider.getDeviceName("/dev/sda1"));
     assertEquals("cl-home", DefaultStorageMediaProvider.getDeviceName("/dev/mapper/cl-home"));
+    assertEquals("nvme0n1", DefaultStorageMediaProvider.getDeviceName("/dev/nvme0n1p6"));
   }
 
   @Test


### PR DESCRIPTION
# NOTICE: Please remove all these generated template comments before request review(include this line)

<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#123] feat(server,coordinator): support xxx"
     - "[#123] feat(common): support xxx"
     - "[MINOR] improvement(script): fix style"
     - "[MINOR] improvement(ci): add some examples and notice"
     - "[#233] fix: check null before access result in xxx"
     - "[#233][FOLLOWUP] improvement(dashboard): display something xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?
<!--
(Please outline the changes and how this PR fixes the issue.)
-->
When I run the unit tests on the `/dev/nvme0n1p6` filesystem, Linux incorrectly assumes that this in a HDD. It tries to read info from `/sys/block/nvme0n1p/queue/rotational` but it should read info from `/sys/block/nvme0n1/queue/rotational`.

The method `getDeviceName` correctly removes the numbers at the end from `sda1` to create a device name `sda` but it does not handle nvme devices correctly, mount point  `nvme0n1p6` should return `nvme0n1` as device name, we need to remove the `p6` part. 

### Why are the changes needed?
<!--
(Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, describe the bug.)

Fix: # (issue)
-->

```
[INFO] Running org.apache.uniffle.server.storage.LocalStorageManagerTest                                                 
[ERROR] Tests run: 7, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 2.879 s <<< FAILURE! - in org.apache.uniffle.server.storage.LocalStorageManagerTest
[ERROR] testGetLocalStorageInfo  Time elapsed: 0.091 s  <<< FAILURE!                                                     
org.opentest4j.AssertionFailedError: expected: <SSD> but was: <HDD>                 
        at org.junit.jupiter.api.AssertionUtils.fail(AssertionUtils.java:55)                                             
        at org.junit.jupiter.api.AssertionUtils.failNotEqual(AssertionUtils.java:62)                            
        at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:182)                               
        at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:177)                   
        at org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:1141) 
        at org.apache.uniffle.server.storage.LocalStorageManagerTest.testGetLocalStorageInfo(LocalStorageManagerTest.java:334)	
```

### Does this PR introduce _any_ user-facing change?
<!--
(Please list the user-facing changes introduced by your change, including
  1. Change in user-facing APIs.
  2. Addition or removal of property keys.)
-->
No.

### How was this patch tested?
<!--
(Please test your changes, and provide instructions on how to test it:
  1. If you add a feature or fix a bug, add a test to cover your changes. 
  2. If you fix a flaky test, repeat it for many times to prove it works.)
-->
UT