### PR TITLE
fix(test): Fix test about default storage type for DefaultStorageMediaProviderTest

### DIFF
--- a/storage/src/test/java/org/apache/uniffle/storage/common/DefaultStorageMediaProviderTest.java
+++ b/storage/src/test/java/org/apache/uniffle/storage/common/DefaultStorageMediaProviderTest.java
@@ -40,8 +40,9 @@ public class DefaultStorageMediaProviderTest {
         StorageMedia.OBJECT_STORE, provider.getStorageMediaFor("cos://bucket-name/b/path"));
 
     // by default, the local file should report as HDD
-    assertEquals(StorageMedia.HDD, provider.getStorageMediaFor("/path/to/base/dir"));
-    assertEquals(StorageMedia.HDD, provider.getStorageMediaFor("file:///path/to/a/dir"));
+    assertEquals(StorageMedia.HDD, provider.getStorageMediaFor("path/to/base/dir"));
+    assertEquals(
+        provider.getStorageMediaFor("/"), provider.getStorageMediaFor("file:///path/to/a/dir"));
 
     // invalid uri should also be reported as HDD
     assertEquals(StorageMedia.HDD, provider.getStorageMediaFor("file@xx:///path/to/a"));


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#123] feat(server,coordinator): support xxx"
     - "[#123] feat(common): support xxx"
     - "[MINOR] improvement(script): fix style"
     - "[MINOR] improvement(ci): add some examples and notice"
     - "[#233] fix: check null before access result in xxx"
     - "[#233][FOLLOWUP] improvement(dashboard): display something xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?
<!--
(Please outline the changes and how this PR fixes the issue.)
-->

This part of `testStorageProvider` should test the default storage media for a non-existent directory. But 47cac3918ff6cdd3873754acc4d6524c4326c604 changed the behavior of `getStorageMediaFor`, now it checks the parent directory (recursively)  so for `/path/to/base/dir` it will end up checking `/` which is existent. With this change it will check `path` which is missing, so it will really check the default value.

### Why are the changes needed?
<!--
(Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, describe the bug.)

Fix: # (issue)
-->

```
[INFO] Running org.apache.uniffle.storage.common.DefaultStorageMediaProviderTest                                         
[ERROR] Tests run: 3, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.586 s <<< FAILURE! - in org.apache.uniffle.storage.common.DefaultStorageMediaProviderTest
[ERROR] testStorageProvider  Time elapsed: 0.017 s  <<< FAILURE!                                                         
org.opentest4j.AssertionFailedError: expected: <HDD> but was: <SSD>                 
        at org.junit.jupiter.api.AssertionUtils.fail(AssertionUtils.java:55)                                             
        at org.junit.jupiter.api.AssertionUtils.failNotEqual(AssertionUtils.java:62)                            
        at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:182)                               
        at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:177)                   
        at org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:1141) 
        at org.apache.uniffle.storage.common.DefaultStorageMediaProviderTest.testStorageProvider(DefaultStorageMediaProviderTest.java:43)  
```

### Does this PR introduce _any_ user-facing change?
<!--
(Please list the user-facing changes introduced by your change, including
  1. Change in user-facing APIs.
  2. Addition or removal of property keys.)
-->
No.

### How was this patch tested?
<!--
(Please test your changes, and provide instructions on how to test it:
  1. If you add a feature or fix a bug, add a test to cover your changes. 
  2. If you fix a flaky test, repeat it for many times to prove it works.)
-->

UT
