### PR TITLE
[#1651] fix(netty): Set Netty as the default server type

### DIFF
--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServer.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServer.java
@@ -575,7 +575,7 @@ public class ShuffleServer {
   }
 
   public int getNettyPort() {
-    return nettyPort;
+    return nettyServerEnabled ? nettyPort : -1;
   }
 
   public int getJettyPort() {


### PR DESCRIPTION
### What changes were proposed in this pull request?

When Netty is closed, the Netty port is not passed

### Why are the changes needed?

Fix mr integration test

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

integration test.
