### PR TITLE
[#2414] Improvement: fix warning unchecked conversion type as a member of the raw type ReconfigurableConfManager

### DIFF
--- a/common/src/main/java/org/apache/uniffle/common/ReconfigurableConfManager.java
+++ b/common/src/main/java/org/apache/uniffle/common/ReconfigurableConfManager.java
@@ -149,9 +149,7 @@ public class ReconfigurableConfManager<T> {
    * @param rssConfFilePath the rss conf file path for reloading
    */
   public static void init(RssConf rssConf, String rssConfFilePath) {
-    ReconfigurableConfManager manager =
-        new ReconfigurableConfManager(rssConf, rssConfFilePath, rssConf.getClass());
-    reconfigurableConfManager = manager;
+    reconfigurableConfManager = new ReconfigurableConfManager<>(rssConf, rssConfFilePath, rssConf.getClass());
   }
 
   /**
@@ -162,8 +160,7 @@ public class ReconfigurableConfManager<T> {
    */
   @VisibleForTesting
   protected static void initForTest(RssConf rssConf, Supplier<RssConf> confSupplier) {
-    ReconfigurableConfManager manager = new ReconfigurableConfManager(rssConf, confSupplier);
-    reconfigurableConfManager = manager;
+    reconfigurableConfManager = new ReconfigurableConfManager<>(rssConf, confSupplier);
   }
 
   /**
@@ -180,9 +177,7 @@ public class ReconfigurableConfManager<T> {
     }
 
     reconfigurableConfManager.registerInternal(configOption);
-    Reconfigurable<T> reconfigurable =
-        new Reconfigurable<T>(reconfigurableConfManager, configOption);
-    return reconfigurable;
+    return new Reconfigurable<>(reconfigurableConfManager, configOption);
   }
 
   public static class FixedReconfigurable<T> extends Reconfigurable<T> {

--- a/common/src/main/java/org/apache/uniffle/common/ReconfigurableConfManager.java
+++ b/common/src/main/java/org/apache/uniffle/common/ReconfigurableConfManager.java
@@ -149,7 +149,8 @@ public class ReconfigurableConfManager<T> {
    * @param rssConfFilePath the rss conf file path for reloading
    */
   public static void init(RssConf rssConf, String rssConfFilePath) {
-    reconfigurableConfManager = new ReconfigurableConfManager<>(rssConf, rssConfFilePath, rssConf.getClass());
+    reconfigurableConfManager =
+        new ReconfigurableConfManager<>(rssConf, rssConfFilePath, rssConf.getClass());
   }
 
   /**


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix warning unchecked conversion type as a member of the raw type `ReconfigurableConfManager`

### Why are the changes needed?
Fix: #2414

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
TBD


