### PR TITLE
[#2426] improvement: Skip the application which is expired when flushing buffers

### DIFF
--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServerConf.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServerConf.java
@@ -481,7 +481,7 @@ public class ShuffleServerConf extends RssBaseConf {
                   + " But SKIP_LIST doesn't support the slow-start feature of MR.");
 
   public static final ConfigOption<Integer> SERVER_SHUFFLE_FLUSH_TRYLOCK_TIMEOUT =
-      ConfigOptions.key("rss.server.shuffleBuffer.flush.tryLock.timeout.ms")
+      ConfigOptions.key("rss.server.flush.tryLockTimeoutMs")
           .intType()
           .defaultValue(100)
           .withDescription("Before the shuffle buffers of the application flush, "

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServerConf.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServerConf.java
@@ -480,6 +480,14 @@ public class ShuffleServerConf extends RssBaseConf {
                   + " The cpu usage of the shuffle server will be reduced."
                   + " But SKIP_LIST doesn't support the slow-start feature of MR.");
 
+  public static final ConfigOption<Integer> SERVER_SHUFFLE_FLUSH_TRYLOCK_TIMEOUT =
+      ConfigOptions.key("rss.server.shuffleBuffer.flush.tryLock.timeout.ms")
+          .intType()
+          .defaultValue(100)
+          .withDescription("Before the shuffle buffers of the application flush, "
+              + "it will try to get the lock of the application. If the time to wait for the lock"
+              + " is too long, the rpc threads will be blocked for a long time.");
+
   public static final ConfigOption<Long> SERVER_SHUFFLE_FLUSH_THRESHOLD =
       ConfigOptions.key("rss.server.shuffle.flush.threshold")
           .longType()

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServerConf.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServerConf.java
@@ -484,9 +484,10 @@ public class ShuffleServerConf extends RssBaseConf {
       ConfigOptions.key("rss.server.flush.tryLockTimeoutMs")
           .intType()
           .defaultValue(100)
-          .withDescription("Before the shuffle buffers of the application flush, "
-              + "it will try to get the lock of the application. If the time to wait for the lock"
-              + " is too long, the rpc threads will be blocked for a long time.");
+          .withDescription(
+              "Before the shuffle buffers of the application flush, "
+                  + "it will try to get the lock of the application. If the time to wait for the lock"
+                  + " is too long, the rpc threads will be blocked for a long time.");
 
   public static final ConfigOption<Long> SERVER_SHUFFLE_FLUSH_THRESHOLD =
       ConfigOptions.key("rss.server.shuffle.flush.threshold")


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#123] feat(server,coordinator): support xxx"
     - "[#123] feat(common): support xxx"
     - "[MINOR] improvement(script): fix style"
     - "[MINOR] improvement(ci): add some examples and notice"
     - "[#233] fix: check null before access result in xxx"
     - "[#233][FOLLOWUP] improvement(dashboard): display something xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?
<!--
(Please outline the changes and how this PR fixes the issue.)
-->
Skip the application which is expired when flushing buffers.
### Why are the changes needed?
<!--
(Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, describe the bug.)
-->

All RPC executors will be blocked when flushBuffer and removeResources are triggered at the same time in the same app.
Fix: #2426

### Does this PR introduce _any_ user-facing change?
<!--
(Please list the user-facing changes introduced by your change, including
  1. Change in user-facing APIs.
  2. Addition or removal of property keys.)
-->
No.

### How was this patch tested?
<!--
(Please test your changes, and provide instructions on how to test it:
  1. If you add a feature or fix a bug, add a test to cover your changes. 
  2. If you fix a flaky test, repeat it for many times to prove it works.)
-->

Existing UTs.