### PR TITLE
[Minor] Eliminate the usage of the shaded Guava Sets class

### DIFF
--- a/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleServerGrpcNettyClient.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleServerGrpcNettyClient.java
@@ -18,6 +18,7 @@
 package org.apache.uniffle.client.impl.grpc;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -26,7 +27,6 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.lang3.tuple.Pair;
-import org.apache.hbase.thirdparty.org.glassfish.jersey.internal.guava.Sets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -142,7 +142,7 @@ public class ShuffleServerGrpcNettyClient extends ShuffleServerGrpcClient {
     int stageAttemptNumber = request.getStageAttemptNumber();
     boolean isSuccessful = true;
     AtomicReference<StatusCode> failedStatusCode = new AtomicReference<>(StatusCode.INTERNAL_ERROR);
-    Set<Integer> needSplitPartitionIds = Sets.newHashSet();
+    Set<Integer> needSplitPartitionIds = new HashSet<>();
     for (Map.Entry<Integer, Map<Integer, List<ShuffleBlockInfo>>> stb :
         shuffleIdToBlocks.entrySet()) {
       int shuffleId = stb.getKey();


### PR DESCRIPTION
# NOTICE: Please remove all these generated template comments before request review(include this line)


### What changes were proposed in this pull request?
<!--
(Please outline the changes and how this PR fixes the issue.)
-->

Replacing shaded guava's  Sets class usage with HashSet

### Why are the changes needed?


Hadoop can throw this error if the classpath is not correctly set.

```
org.apache.uniffle.client.impl.ShuffleWriteClientImpl: Unexpected exceptions occurred while sending shuffle data
java.util.concurrent.CompletionException: java.lang.NoClassDefFoundError: org/apache/hbase/thirdparty/org/glassfish/jersey/internal/guava/Sets
        at java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:273)
```

### Does this PR introduce _any_ user-facing change?
<!--
(Please list the user-facing changes introduced by your change, including
  1. Change in user-facing APIs.
  2. Addition or removal of property keys.)
-->
No.

### How was this patch tested?
<!--
(Please test your changes, and provide instructions on how to test it:
  1. If you add a feature or fix a bug, add a test to cover your changes. 
  2. If you fix a flaky test, repeat it for many times to prove it works.)
-->
UT