### PR TITLE
[MINOR] improvement(client): Detailed error message in ShuffleWriteClientImpl

### DIFF
--- a/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
@@ -703,9 +703,9 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
               + partitionNumPerRange
               + "] to coordinator. "
               + "Error message: "
-              + response.getMessage();
+              + e.getMessage();
       LOG.error(msg);
-      throw new RssException(msg);
+      throw new RssException(msg, e);
     }
 
     return new ShuffleAssignmentsInfo(


### PR DESCRIPTION
### What changes were proposed in this pull request?
<!--
(Please outline the changes and how this PR fixes the issue.)
-->

Improving error message in `ShuffleWriteClientImpl`

### Why are the changes needed?
<!--
(Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, describe the bug.)

Fix: # (issue)
-->

`ShuffleWriteClientImpl` prints out this error message, which is not very useful:

```
org.apache.uniffle.common.exception.RssException: getShuffleAssignments or registerShuffle failed!                                                                                            
        at org.apache.uniffle.shuffle.manager.RssShuffleManagerBase.requestShuffleAssignment(RssShuffleManagerBase.java:1378)                                                                 
        at org.apache.uniffle.shuffle.manager.RssShuffleManagerBase.requestShuffleAssignment(RssShuffleManagerBase.java:1390)                                                                 
        at org.apache.spark.shuffle.RssShuffleManager.registerShuffle(RssShuffleManager.java:150)                                                                                             
        at org.apache.spark.ShuffleDependency.<init>(Dependency.scala:93)     
        ...
Caused by: org.apache.uniffle.common.exception.RssException: Error happened when getShuffleAssignments with appId[local-1743762415951_1743762414837], shuffleId[0], numMaps[2], partitionNumPe
rRange[1] to coordinator. Error message:                                                                                                                                                      
        at org.apache.uniffle.client.impl.ShuffleWriteClientImpl.getShuffleAssignments(ShuffleWriteClientImpl.java:708)                                                                       
        at org.apache.uniffle.shuffle.manager.RssShuffleManagerBase.lambda$requestShuffleAssignment$9(RssShuffleManagerBase.java:1353)                                                        
        at org.apache.uniffle.common.util.RetryUtils.retryWithCondition(RetryUtils.java:81)                                                                                                   
        at org.apache.uniffle.common.util.RetryUtils.retry(RetryUtils.java:61)                                                                                                                
        at org.apache.uniffle.common.util.RetryUtils.retry(RetryUtils.java:32)                                                                                                                
        at org.apache.uniffle.shuffle.manager.RssShuffleManagerBase.requestShuffleAssignment(RssShuffleManagerBase.java:1348)                                                                 
        ... 78 more  
```

with this fix, the error message is:

```
org.apache.uniffle.common.exception.RssException: getShuffleAssignments or registerShuffle failed!                                                                                            
        at org.apache.uniffle.shuffle.manager.RssShuffleManagerBase.requestShuffleAssignment(RssShuffleManagerBase.java:1378)                                                                 
        at org.apache.uniffle.shuffle.manager.RssShuffleManagerBase.requestShuffleAssignment(RssShuffleManagerBase.java:1390)                                                                 
        at org.apache.spark.shuffle.RssShuffleManager.registerShuffle(RssShuffleManager.java:150)                                                                                             
        at org.apache.spark.ShuffleDependency.<init>(Dependency.scala:93)     
        ...
Caused by: org.apache.uniffle.common.exception.RssException: Error happened when getShuffleAssignments with appId[local-1743773004981_1743773003965], shuffleId[0], numMaps[2], partitionNumPe
rRange[1] to coordinator. Error message: getShuffleAssignments failed!                                                                                                                        
        at org.apache.uniffle.client.impl.ShuffleWriteClientImpl.getShuffleAssignments(ShuffleWriteClientImpl.java:708)                                                                       
        at org.apache.uniffle.shuffle.manager.RssShuffleManagerBase.lambda$requestShuffleAssignment$9(RssShuffleManagerBase.java:1353)                                                        
        at org.apache.uniffle.common.util.RetryUtils.retryWithCondition(RetryUtils.java:81)                                                                                                   
        at org.apache.uniffle.common.util.RetryUtils.retry(RetryUtils.java:61)                                                                                                                
        at org.apache.uniffle.common.util.RetryUtils.retry(RetryUtils.java:32)                                                                                                                
        at org.apache.uniffle.shuffle.manager.RssShuffleManagerBase.requestShuffleAssignment(RssShuffleManagerBase.java:1348)                                                                 
        ... 78 more                                                                                                                                                                           
Caused by: org.apache.uniffle.common.exception.RssException: getShuffleAssignments failed!                                                                                                    
        at org.apache.uniffle.client.impl.grpc.CoordinatorGrpcRetryableClient.getShuffleAssignments(CoordinatorGrpcRetryableClient.java:187)                                                  
        at org.apache.uniffle.client.impl.ShuffleWriteClientImpl.getShuffleAssignments(ShuffleWriteClientImpl.java:692)                                                                       
        ... 83 more                                                                                                                                                                           
Caused by: org.apache.uniffle.common.exception.RssException: There isn't enough shuffle servers                                                                                               
        at org.apache.uniffle.client.impl.grpc.CoordinatorGrpcRetryableClient.lambda$getShuffleAssignments$4(CoordinatorGrpcRetryableClient.java:180)                                         
        at org.apache.uniffle.common.util.RetryUtils.retryWithCondition(RetryUtils.java:81)                                                                                                   
        at org.apache.uniffle.common.util.RetryUtils.retry(RetryUtils.java:61)                                                                                                                
        at org.apache.uniffle.common.util.RetryUtils.retry(RetryUtils.java:32)                                                                                                                
        at org.apache.uniffle.client.impl.grpc.CoordinatorGrpcRetryableClient.getShuffleAssignments(CoordinatorGrpcRetryableClient.java:162)                                                  
        ... 84 more
```
### Does this PR introduce _any_ user-facing change?
<!--
(Please list the user-facing changes introduced by your change, including
  1. Change in user-facing APIs.
  2. Addition or removal of property keys.)
-->
No.

### How was this patch tested?
<!--
(Please test your changes, and provide instructions on how to test it:
  1. If you add a feature or fix a bug, add a test to cover your changes. 
  2. If you fix a flaky test, repeat it for many times to prove it works.)
-->
UTs
