### PR TITLE
[#2082] fix: spark executor task error when reading shuffle data when  using java open jdk11

### DIFF
--- a/client/src/main/java/org/apache/uniffle/client/impl/ShuffleReadClientImpl.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/ShuffleReadClientImpl.java
@@ -310,9 +310,6 @@ public class ShuffleReadClientImpl implements ShuffleReadClient {
     if (sdr == null) {
       return 0;
     }
-    if (readBuffer != null) {
-      RssUtils.releaseByteBuffer(readBuffer);
-    }
     readBuffer = sdr.getDataBuffer();
     if (readBuffer == null || readBuffer.capacity() == 0) {
       return 0;
@@ -330,9 +327,6 @@ public class ShuffleReadClientImpl implements ShuffleReadClient {
   public void close() {
     if (sdr != null) {
       sdr.release();
-    }
-    if (readBuffer != null) {
-      RssUtils.releaseByteBuffer(readBuffer);
     }
     if (clientReadHandler != null) {
       clientReadHandler.close();


### PR DESCRIPTION
### What changes were proposed in this pull request?

Remove unnecessary release for ByteBuf

### Why are the changes needed?

Fix: #2082

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
CI passed. User verified this fix in the production environment.
