### PR TITLE
fix(spark3): Reserve previous writer initialization way for gluten + uniffle

### DIFF
--- a/client-spark/common/src/main/java/org/apache/uniffle/shuffle/manager/RssShuffleManagerBase.java
+++ b/client-spark/common/src/main/java/org/apache/uniffle/shuffle/manager/RssShuffleManagerBase.java
@@ -928,6 +928,10 @@ public abstract class RssShuffleManagerBase implements RssShuffleManagerInterfac
     return managerClientSupplier;
   }
 
+  public Supplier<ShuffleManagerClient> getShuffleManagerClientSupplier() {
+    return managerClientSupplier;
+  }
+
   @Override
   public ShuffleHandleInfo getShuffleHandleInfoByShuffleId(int shuffleId) {
     return shuffleHandleInfoManager.get(shuffleId);

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
@@ -231,6 +231,34 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
     this.recordReportFailedShuffleservers = Sets.newConcurrentHashSet();
   }
 
+  // Gluten needs this method
+  public RssShuffleWriter(
+      String appId,
+      int shuffleId,
+      String taskId,
+      long taskAttemptId,
+      ShuffleWriteMetrics shuffleWriteMetrics,
+      RssShuffleManager shuffleManager,
+      SparkConf sparkConf,
+      ShuffleWriteClient shuffleWriteClient,
+      RssShuffleHandle<K, V, C> rssHandle,
+      Function<String, Boolean> taskFailureCallback,
+      TaskContext context) {
+    this(
+        appId,
+        shuffleId,
+        taskId,
+        taskAttemptId,
+        shuffleWriteMetrics,
+        shuffleManager,
+        sparkConf,
+        shuffleWriteClient,
+        shuffleManager.getShuffleManagerClientSupplier(),
+        rssHandle,
+        taskFailureCallback,
+        context);
+  }
+
   public RssShuffleWriter(
       String appId,
       int shuffleId,


### PR DESCRIPTION
### What changes were proposed in this pull request?

Now the master branch code is not compatible with the gluten latest version, this is caused by the #1838.
And so this PR is to fix this uncompatible problem.

Please see https://github.com/apache/incubator-gluten/blob/main/backends-velox/src-uniffle/main/java/org/apache/spark/shuffle/writer/VeloxUniffleColumnarShuffleWriter.java

### Why are the changes needed?

Fix compatibility with gluten 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Internal production tests.
