### PR TITLE
[MINOR] docs: fix storage type in MR / TEZ documentation.

### DIFF
--- a/docs/client_guide/mr_client_guide.md
+++ b/docs/client_guide/mr_client_guide.md
@@ -57,4 +57,4 @@ This experimental feature allows to reduce tasks to spill data to remote storage
 |mapreduce.rss.reduce.remote.spill.replication|1| The replication number to spill data to Hadoop FS                      |
 |mapreduce.rss.reduce.remote.spill.retries|5| The retry number to spill data to Hadoop FS                            |
 
-Notice: this feature requires the MEMORY_LOCAL_HADOOP mode.
+Notice: this feature requires the MEMORY_LOCALFILE_HDFS storage type mode.

--- a/docs/client_guide/tez_client_guide.md
+++ b/docs/client_guide/tez_client_guide.md
@@ -60,4 +60,4 @@ This experimental feature allows to reduce tasks to spill data to remote storage
 |tez.rss.reduce.remote.spill.replication|1| The replication number to spill data to Hadoop FS                      |
 |tez.rss.reduce.remote.spill.retries|5| The retry number to spill data to Hadoop FS                            |
 
-Notice: this feature requires the MEMORY_LOCAL_HADOOP mode.
+Notice: this feature requires the MEMORY_LOCALFILE_HDFS storage type mode.


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fixing storage type in documentation.

### Why are the changes needed?

The documentation refers to MEMORY_LOCAL_HADOOP mode.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Not tested, this is just a documentation change.