### PR TITLE
[MINOR] fix(tez): Use correct Field object for InputDescriptor className

### DIFF
--- a/client-tez/src/main/java/org/apache/tez/dag/app/RssDAGAppMaster.java
+++ b/client-tez/src/main/java/org/apache/tez/dag/app/RssDAGAppMaster.java
@@ -605,9 +605,9 @@ public class RssDAGAppMaster extends DAGAppMaster {
           // rename input class name
           InputDescriptor inputDescriptor = edge.getEdgeProperty().getEdgeDestination();
           Field inputClassNameField =
-              outputDescriptor.getClass().getSuperclass().getDeclaredField("className");
+              inputDescriptor.getClass().getSuperclass().getDeclaredField("className");
           inputClassNameField.setAccessible(true);
-          String inputClassName = (String) outputClassNameField.get(inputDescriptor);
+          String inputClassName = (String) inputClassNameField.get(inputDescriptor);
           String rssInputClassName =
               RssTezUtils.replaceRssInputClassName(
                   inputClassName,
@@ -616,7 +616,7 @@ public class RssDAGAppMaster extends DAGAppMaster {
                       .getBoolean(
                           RssTezConfig.RSS_REMOTE_MERGE_ENABLE,
                           RssTezConfig.RSS_REMOTE_MERGE_ENABLE_DEFAULT));
-          outputClassNameField.set(inputDescriptor, rssInputClassName);
+          inputClassNameField.set(inputDescriptor, rssInputClassName);
         }
       } catch (IOException | IllegalAccessException | NoSuchFieldException e) {
         LOG.error("Reconfigure failed after dag was inited, caused by {}", e);


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR corrects the reflection logic in `RssDAGAppMaster.DagInitialCallback` when setting the `className` for `InputDescriptor`. It now correctly obtains the `Field` object directly from `InputDescriptor`'s class hierarchy, instead of incorrectly reusing the `Field` object derived from `OutputDescriptor`.

### Why are the changes needed?
The previous code mistakenly used the `Field` for `className` obtained from `OutputDescriptor` to modify the `InputDescriptor`.

This **happened to work** likely because both `InputDescriptor` and `OutputDescriptor` inherit the `className` field from a common superclass. Java's reflection allows applying a `Field` object to any instance that possesses that field (often through inheritance), even if the `Field` was retrieved via a different related class.

This fix ensures the reflection is used correctly and explicitly for `InputDescriptor`, improving code clarity, robustness, and maintainability.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Existing tests.
