### PR TITLE
[MINOR] fix(docker): Fix hadoop version

### DIFF
--- a/deploy/kubernetes/docker/build.sh
+++ b/deploy/kubernetes/docker/build.sh
@@ -52,6 +52,7 @@ while (( "$#" )); do
       ;;
     --hadoop-version)
       HADOOP_VERSION="$2"
+      HADOOP_SHORT_VERSION=$(echo "$HADOOP_VERSION" | awk -F "." '{print $1"."$2}')
       shift
       ;;
     --author)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Setting correct `HADOOP_SHORT_VERSION` if we provide `--hadoop-version`.

### Why are the changes needed?

Without this, if we specify `--hadoop-version 3.2.1` it installs hadoop 3.2.1 to the image with `rss-0.11.0-SNAPSHOT-hadoop2.8.tgz` instead of the correct `rss-0.11.0-SNAPSHOT-hadoop3.2.tgz`

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?
Running the script locally.
