### PR TITLE
[Improvement] Clear the alarm log when starting the relevant service

### DIFF
--- a/bin/start-coordinator.sh
+++ b/bin/start-coordinator.sh
@@ -93,6 +93,7 @@ GC_LOG_ARGS_NEW=" -XX:+IgnoreUnrecognizedVMOptions \
           -Xlog:gc+phases=debug \
           -Xlog:gc+ref=debug \
           -Xlog:gc+start=debug \
+          --add-opens java.base/java.lang=ALL-UNNAMED \
           -Xlog:gc*:file=${RSS_LOG_DIR}/gc-%t.log:tags,uptime,time,level"
 
 JVM_LOG_ARGS=""

--- a/common/src/main/java/org/apache/uniffle/common/web/JettyServer.java
+++ b/common/src/main/java/org/apache/uniffle/common/web/JettyServer.java
@@ -155,6 +155,7 @@ public class JettyServer {
     resourcePackages.addAll(Arrays.asList(packages));
     servletHolder.setInitParameter(
         ServerProperties.PROVIDER_PACKAGES, String.join(",", resourcePackages));
+    // Turn off wadl.
     servletHolder.setInitParameter(ServerProperties.WADL_FEATURE_DISABLE, "true");
   }
 

--- a/common/src/main/java/org/apache/uniffle/common/web/JettyServer.java
+++ b/common/src/main/java/org/apache/uniffle/common/web/JettyServer.java
@@ -155,6 +155,7 @@ public class JettyServer {
     resourcePackages.addAll(Arrays.asList(packages));
     servletHolder.setInitParameter(
         ServerProperties.PROVIDER_PACKAGES, String.join(",", resourcePackages));
+    servletHolder.setInitParameter(ServerProperties.WADL_FEATURE_DISABLE, "true");
   }
 
   public void registerInstance(Class<?> clazz, Object instance) {

--- a/common/src/main/java/org/apache/uniffle/common/web/resource/MetricResource.java
+++ b/common/src/main/java/org/apache/uniffle/common/web/resource/MetricResource.java
@@ -38,7 +38,6 @@ public class MetricResource extends BaseMetricResource {
   @Context protected ServletContext servletContext;
 
   @GET
-  @Path("/")
   public MetricsJsonObj metrics(@QueryParam("name[]") Set<String> names) {
     return metrics(null, names);
   }

--- a/dashboard/src/main/java/org/apache/uniffle/dashboard/web/Dashboard.java
+++ b/dashboard/src/main/java/org/apache/uniffle/dashboard/web/Dashboard.java
@@ -121,6 +121,7 @@ public class Dashboard {
     ServletHolder servletHolder = contextHandler.addServlet(ServletContainer.class, "/*");
     servletHolder.setInitParameter(
         ServerProperties.PROVIDER_PACKAGES, "org.apache.uniffle.dashboard.web.resource");
+    // Turn off wadl.
     servletHolder.setInitParameter(ServerProperties.WADL_FEATURE_DISABLE, "true");
     contextHandler.setAttribute("coordinatorServerAddresses", coordinatorServerAddresses);
     contextHandler.setAttribute(Dashboard.class.getCanonicalName(), this);

--- a/dashboard/src/main/java/org/apache/uniffle/dashboard/web/Dashboard.java
+++ b/dashboard/src/main/java/org/apache/uniffle/dashboard/web/Dashboard.java
@@ -121,6 +121,7 @@ public class Dashboard {
     ServletHolder servletHolder = contextHandler.addServlet(ServletContainer.class, "/*");
     servletHolder.setInitParameter(
         ServerProperties.PROVIDER_PACKAGES, "org.apache.uniffle.dashboard.web.resource");
+    servletHolder.setInitParameter(ServerProperties.WADL_FEATURE_DISABLE, "true");
     contextHandler.setAttribute("coordinatorServerAddresses", coordinatorServerAddresses);
     contextHandler.setAttribute(Dashboard.class.getCanonicalName(), this);
     return contextHandler;


### PR DESCRIPTION
### What changes were proposed in this pull request?

When using a high version of JDK9.0 or above, when starting services such as Coordinator and Shuffle Server for the first time and when http services are accessible, some alarm logs will be printed. Although it doesn't affect the service, it's very uncomfortable to print.

![Image](https://github.com/user-attachments/assets/758877a4-db81-4b13-ac01-8879fa2a16c0)
![image](https://github.com/user-attachments/assets/23a745eb-3781-4699-b620-be667c2f8a37)

`WARNING: Illegal reflective access by com.sun.xml.bind.v2.runtime.reflect.opt.Injector$1 (file:/hadoop/share/hadoop/common/lib/jaxb-impl-2.2.3-1.jar) to method java.lang.ClassLoader.defineClass(java.lang.String,byte[],int,int)
WARNING: Please consider reporting this to the maintainers of com.sun.xml.bind.v2.runtime.reflect.opt.Injector$1
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
Apr 15, 2025 8:32:52 PM org.apache.hbase.thirdparty.org.glassfish.jersey.internal.Errors logErrors
WARNING: The following warnings have been detected: WARNING: The (sub)resource method metrics in org.apache.uniffle.common.web.resource.MetricResource contains empty path annotation.`


### Why are the changes needed?

Fix: #2451

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

The existing UT.
