### PR TITLE
[#2457] feat(spark): Introducing shuffle-server data push statistics

### DIFF
--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/AddBlockEvent.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/AddBlockEvent.java
@@ -28,17 +28,22 @@ public class AddBlockEvent {
   private int stageAttemptNumber;
   private List<ShuffleBlockInfo> shuffleDataInfoList;
   private List<Runnable> processedCallbackChain;
+  private WriteBufferManager bufferManager;
 
   public AddBlockEvent(String taskId, List<ShuffleBlockInfo> shuffleDataInfoList) {
-    this(taskId, 0, shuffleDataInfoList);
+    this(taskId, 0, shuffleDataInfoList, null);
   }
 
   public AddBlockEvent(
-      String taskId, int stageAttemptNumber, List<ShuffleBlockInfo> shuffleDataInfoList) {
+      String taskId,
+      int stageAttemptNumber,
+      List<ShuffleBlockInfo> shuffleDataInfoList,
+      WriteBufferManager writeBufferManager) {
     this.taskId = taskId;
     this.stageAttemptNumber = stageAttemptNumber;
     this.shuffleDataInfoList = shuffleDataInfoList;
     this.processedCallbackChain = new ArrayList<>();
+    this.bufferManager = writeBufferManager;
   }
 
   /** @param callback, should not throw any exception and execute fast. */
@@ -60,6 +65,10 @@ public class AddBlockEvent {
 
   public List<Runnable> getProcessedCallbackChain() {
     return processedCallbackChain;
+  }
+
+  public WriteBufferManager getBufferManager() {
+    return bufferManager;
   }
 
   @Override

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/DataPusher.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/DataPusher.java
@@ -36,6 +36,7 @@ import org.slf4j.LoggerFactory;
 
 import org.apache.uniffle.client.api.ShuffleWriteClient;
 import org.apache.uniffle.client.impl.FailedBlockSendTracker;
+import org.apache.uniffle.client.impl.ShuffleServerPushCostTracker;
 import org.apache.uniffle.client.response.SendShuffleDataResult;
 import org.apache.uniffle.common.ShuffleBlockInfo;
 import org.apache.uniffle.common.exception.RssException;
@@ -100,6 +101,11 @@ public class DataPusher implements Closeable {
                 putFailedBlockSendTracker(
                     taskToFailedBlockSendTracker, taskId, result.getFailedBlockSendTracker());
               } finally {
+                ShuffleServerPushCostTracker shuffleServerPushCostTracker =
+                    result.getShuffleServerPushCostTracker();
+                WriteBufferManager bufferManager = event.getBufferManager();
+                bufferManager.merge(shuffleServerPushCostTracker);
+
                 Set<Long> succeedBlockIds = getSucceedBlockIds(result);
                 for (ShuffleBlockInfo block : shuffleBlockInfoList) {
                   block.executeCompletionCallback(succeedBlockIds.contains(block.getBlockId()));

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/DataPusher.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/DataPusher.java
@@ -101,10 +101,12 @@ public class DataPusher implements Closeable {
                 putFailedBlockSendTracker(
                     taskToFailedBlockSendTracker, taskId, result.getFailedBlockSendTracker());
               } finally {
-                ShuffleServerPushCostTracker shuffleServerPushCostTracker =
-                    result.getShuffleServerPushCostTracker();
                 WriteBufferManager bufferManager = event.getBufferManager();
-                bufferManager.merge(shuffleServerPushCostTracker);
+                if (bufferManager != null) {
+                  ShuffleServerPushCostTracker shuffleServerPushCostTracker =
+                      result.getShuffleServerPushCostTracker();
+                  bufferManager.merge(shuffleServerPushCostTracker);
+                }
 
                 Set<Long> succeedBlockIds = getSucceedBlockIds(result);
                 for (ShuffleBlockInfo block : shuffleBlockInfoList) {

--- a/client-spark/common/src/test/java/org/apache/spark/shuffle/writer/DataPusherTest.java
+++ b/client-spark/common/src/test/java/org/apache/spark/shuffle/writer/DataPusherTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.Test;
 
 import org.apache.uniffle.client.factory.ShuffleClientFactory;
 import org.apache.uniffle.client.impl.FailedBlockSendTracker;
+import org.apache.uniffle.client.impl.ShuffleServerPushCostTracker;
 import org.apache.uniffle.client.impl.ShuffleWriteClientImpl;
 import org.apache.uniffle.client.response.SendShuffleDataResult;
 import org.apache.uniffle.common.ShuffleBlockInfo;
@@ -114,7 +115,8 @@ public class DataPusherTest {
     failedBlockSendTracker.add(
         failedBlock2, new ShuffleServerInfo("host", 39998), StatusCode.NO_BUFFER);
     shuffleWriteClient.setFakedShuffleDataResult(
-        new SendShuffleDataResult(Sets.newHashSet(1L, 2L), failedBlockSendTracker));
+        new SendShuffleDataResult(
+            Sets.newHashSet(1L, 2L), failedBlockSendTracker, new ShuffleServerPushCostTracker()));
     ShuffleBlockInfo shuffleBlockInfo =
         new ShuffleBlockInfo(1, 1, 1, 1, 1, new byte[1], null, 1, 100, 1);
     AddBlockEvent event = new AddBlockEvent("taskId", Arrays.asList(shuffleBlockInfo));

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
@@ -368,12 +368,12 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
     checkSentRecordCount(recordCount);
     checkBlockSendResult(new HashSet<>(blockIds));
     checkSentBlockCount();
+    bufferManager.getShuffleServerPushCostTracker().statistics();
     long commitStartTs = System.currentTimeMillis();
     long checkDuration = commitStartTs - checkStartTs;
     if (!isMemoryShuffleEnabled) {
       sendCommit();
     }
-    bufferManager.getShuffleServerPushCostTracker().statistics();
     long writeDurationMs = bufferManager.getWriteTime() + (System.currentTimeMillis() - start);
     shuffleWriteMetrics.incWriteTime(TimeUnit.MILLISECONDS.toNanos(writeDurationMs));
     LOG.info(

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
@@ -373,6 +373,7 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
     if (!isMemoryShuffleEnabled) {
       sendCommit();
     }
+    bufferManager.getShuffleServerPushCostTracker().statistics();
     long writeDurationMs = bufferManager.getWriteTime() + (System.currentTimeMillis() - start);
     shuffleWriteMetrics.incWriteTime(TimeUnit.MILLISECONDS.toNanos(writeDurationMs));
     LOG.info(

--- a/client/src/main/java/org/apache/uniffle/client/impl/ShuffleServerPushCost.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/ShuffleServerPushCost.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.uniffle.client.impl;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+public class ShuffleServerPushCost {
+  private final String shuffleServerId;
+  private final AtomicLong sentBytes;
+  private final AtomicLong sentDurationMs;
+
+  public ShuffleServerPushCost(String shuffleServerId) {
+    this.shuffleServerId = shuffleServerId;
+    this.sentBytes = new AtomicLong();
+    this.sentDurationMs = new AtomicLong();
+  }
+
+  public void incSentBytes(long bytes) {
+    this.sentBytes.addAndGet(bytes);
+  }
+
+  public void incDurationMs(long duration) {
+    this.sentDurationMs.addAndGet(duration);
+  }
+
+  public void merge(ShuffleServerPushCost cost) {
+    if (!cost.shuffleServerId.equals(this.shuffleServerId)) {
+      return;
+    }
+
+    this.incSentBytes(cost.sentBytes.get());
+    this.incDurationMs(cost.sentDurationMs.get());
+  }
+
+  public long speed() {
+    if (sentDurationMs.get() == 0) {
+      return 0L;
+    }
+    return sentBytes.get() / sentDurationMs.get();
+  }
+
+  public long sentBytes() {
+    return sentBytes.get();
+  }
+
+  public long sentDurationMillis() {
+    return sentDurationMs.get();
+  }
+
+  @Override
+  public String toString() {
+    return "ShuffleServerPushCost{"
+        + "shuffleServerId='"
+        + shuffleServerId
+        + ", sentBytes="
+        + sentBytes
+        + ", sentDurationMs="
+        + sentDurationMs
+        + ", speed="
+        + speed()
+        + '}';
+  }
+}

--- a/client/src/main/java/org/apache/uniffle/client/impl/ShuffleServerPushCost.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/ShuffleServerPushCost.java
@@ -73,6 +73,6 @@ public class ShuffleServerPushCost {
         + sentDurationMs
         + ", speed="
         + speed()
-        + '}';
+        + "}";
   }
 }

--- a/client/src/main/java/org/apache/uniffle/client/impl/ShuffleServerPushCostTracker.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/ShuffleServerPushCostTracker.java
@@ -69,7 +69,7 @@ public class ShuffleServerPushCostTracker {
     LOGGER.info(
         "Statistics of shuffle server push speed: \n"
             + "-------------------------------------------"
-            + "\nMinimum: {} \nP25: {} \nMedian: {} \nP75: {} \nMaximum: {}"
+            + "\nMinimum: {} \nP25: {} \nMedian: {} \nP75: {} \nMaximum: {}\n"
             + "-------------------------------------------",
         shuffleServerPushCosts.isEmpty() ? 0 : shuffleServerPushCosts.get(0),
         getPercentile(shuffleServerPushCosts, 25),

--- a/client/src/main/java/org/apache/uniffle/client/impl/ShuffleServerPushCostTracker.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/ShuffleServerPushCostTracker.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.uniffle.client.impl;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** This class is to track the underlying assigned shuffle servers' data pushing speed. */
+public class ShuffleServerPushCostTracker {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ShuffleServerPushCostTracker.class);
+
+  // shuffleServerId -> ShuffleServerPushCost Object
+  private Map<String, ShuffleServerPushCost> tracking;
+
+  public ShuffleServerPushCostTracker() {
+    this.tracking = new ConcurrentHashMap<>();
+  }
+
+  public void merge(ShuffleServerPushCostTracker tracker) {
+    for (Map.Entry<String, ShuffleServerPushCost> entry : tracker.tracking.entrySet()) {
+      String id = entry.getKey();
+      ShuffleServerPushCost cost = entry.getValue();
+      this.tracking.computeIfAbsent(id, key -> new ShuffleServerPushCost(key)).merge(cost);
+    }
+  }
+
+  public void record(String id, long sentBytes, long pushDuration) {
+    ShuffleServerPushCost cost =
+        this.tracking.computeIfAbsent(id, key -> new ShuffleServerPushCost(key));
+    cost.incDurationMs(pushDuration);
+    cost.incSentBytes(sentBytes);
+  }
+
+  public void statistics() {
+    List<ShuffleServerPushCost> shuffleServerPushCosts = new ArrayList<>(this.tracking.values());
+    Collections.sort(
+        shuffleServerPushCosts, Comparator.comparingLong(ShuffleServerPushCost::speed));
+
+    LOGGER.info(
+        "Statistics of shuffle server push speed. Minimum: {}. P25: {}. Median: {}. P75: {}. Maximum: {}",
+        shuffleServerPushCosts.isEmpty() ? 0 : shuffleServerPushCosts.get(0),
+        getPercentile(shuffleServerPushCosts, 25),
+        getPercentile(shuffleServerPushCosts, 50),
+        getPercentile(shuffleServerPushCosts, 75),
+        shuffleServerPushCosts.isEmpty()
+            ? 0
+            : shuffleServerPushCosts.get(shuffleServerPushCosts.size() - 1));
+  }
+
+  private double getPercentile(List<ShuffleServerPushCost> costs, double percentile) {
+    if (costs.isEmpty()) {
+      return 0;
+    }
+    int index = (int) Math.ceil(percentile / 100.0 * costs.size()) - 1;
+    return costs.get(Math.min(Math.max(index, 0), costs.size() - 1)).speed();
+  }
+}

--- a/client/src/main/java/org/apache/uniffle/client/impl/ShuffleServerPushCostTracker.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/ShuffleServerPushCostTracker.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.apache.commons.collections4.CollectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,11 +56,18 @@ public class ShuffleServerPushCostTracker {
 
   public void statistics() {
     List<ShuffleServerPushCost> shuffleServerPushCosts = new ArrayList<>(this.tracking.values());
+    if (CollectionUtils.isEmpty(shuffleServerPushCosts)) {
+      return;
+    }
+
     Collections.sort(
         shuffleServerPushCosts, Comparator.comparingLong(ShuffleServerPushCost::speed));
 
     LOGGER.info(
-        "Statistics of shuffle server push speed. Minimum: {}. P25: {}. Median: {}. P75: {}. Maximum: {}",
+        "Statistics of shuffle server push speed: \n"
+            + "-------------------------------------------"
+            + "\nMinimum: {} \nP25: {} \nMedian: {} \nP75: {} \nMaximum: {}"
+            + "-------------------------------------------",
         shuffleServerPushCosts.isEmpty() ? 0 : shuffleServerPushCosts.get(0),
         getPercentile(shuffleServerPushCosts, 25),
         getPercentile(shuffleServerPushCosts, 50),
@@ -69,11 +77,12 @@ public class ShuffleServerPushCostTracker {
             : shuffleServerPushCosts.get(shuffleServerPushCosts.size() - 1));
   }
 
-  private double getPercentile(List<ShuffleServerPushCost> costs, double percentile) {
+  private ShuffleServerPushCost getPercentile(
+      List<ShuffleServerPushCost> costs, double percentile) {
     if (costs.isEmpty()) {
-      return 0;
+      return null;
     }
     int index = (int) Math.ceil(percentile / 100.0 * costs.size()) - 1;
-    return costs.get(Math.min(Math.max(index, 0), costs.size() - 1)).speed();
+    return costs.get(Math.min(Math.max(index, 0), costs.size() - 1));
   }
 }

--- a/client/src/main/java/org/apache/uniffle/client/impl/ShuffleServerPushCostTracker.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/ShuffleServerPushCostTracker.java
@@ -40,6 +40,9 @@ public class ShuffleServerPushCostTracker {
   }
 
   public void merge(ShuffleServerPushCostTracker tracker) {
+    if (tracker == null) {
+      return;
+    }
     for (Map.Entry<String, ShuffleServerPushCost> entry : tracker.tracking.entrySet()) {
       String id = entry.getKey();
       ShuffleServerPushCost cost = entry.getValue();

--- a/client/src/main/java/org/apache/uniffle/client/response/SendShuffleDataResult.java
+++ b/client/src/main/java/org/apache/uniffle/client/response/SendShuffleDataResult.java
@@ -29,8 +29,7 @@ public class SendShuffleDataResult {
   private ShuffleServerPushCostTracker shuffleServerPushCostTracker;
 
   public SendShuffleDataResult(
-          Set<Long> successBlockIds,
-          FailedBlockSendTracker failedBlockSendTracker) {
+      Set<Long> successBlockIds, FailedBlockSendTracker failedBlockSendTracker) {
     this(successBlockIds, failedBlockSendTracker, new ShuffleServerPushCostTracker());
   }
 

--- a/client/src/main/java/org/apache/uniffle/client/response/SendShuffleDataResult.java
+++ b/client/src/main/java/org/apache/uniffle/client/response/SendShuffleDataResult.java
@@ -29,6 +29,12 @@ public class SendShuffleDataResult {
   private ShuffleServerPushCostTracker shuffleServerPushCostTracker;
 
   public SendShuffleDataResult(
+          Set<Long> successBlockIds,
+          FailedBlockSendTracker failedBlockSendTracker) {
+    this(successBlockIds, failedBlockSendTracker, new ShuffleServerPushCostTracker());
+  }
+
+  public SendShuffleDataResult(
       Set<Long> successBlockIds,
       FailedBlockSendTracker failedBlockSendTracker,
       ShuffleServerPushCostTracker shuffleServerPushCostTracker) {

--- a/client/src/main/java/org/apache/uniffle/client/response/SendShuffleDataResult.java
+++ b/client/src/main/java/org/apache/uniffle/client/response/SendShuffleDataResult.java
@@ -20,16 +20,21 @@ package org.apache.uniffle.client.response;
 import java.util.Set;
 
 import org.apache.uniffle.client.impl.FailedBlockSendTracker;
+import org.apache.uniffle.client.impl.ShuffleServerPushCostTracker;
 
 public class SendShuffleDataResult {
 
   private Set<Long> successBlockIds;
   private FailedBlockSendTracker failedBlockSendTracker;
+  private ShuffleServerPushCostTracker shuffleServerPushCostTracker;
 
   public SendShuffleDataResult(
-      Set<Long> successBlockIds, FailedBlockSendTracker failedBlockSendTracker) {
+      Set<Long> successBlockIds,
+      FailedBlockSendTracker failedBlockSendTracker,
+      ShuffleServerPushCostTracker shuffleServerPushCostTracker) {
     this.successBlockIds = successBlockIds;
     this.failedBlockSendTracker = failedBlockSendTracker;
+    this.shuffleServerPushCostTracker = shuffleServerPushCostTracker;
   }
 
   public Set<Long> getSuccessBlockIds() {
@@ -42,5 +47,9 @@ public class SendShuffleDataResult {
 
   public FailedBlockSendTracker getFailedBlockSendTracker() {
     return failedBlockSendTracker;
+  }
+
+  public ShuffleServerPushCostTracker getShuffleServerPushCostTracker() {
+    return shuffleServerPushCostTracker;
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Introducing shuffle-server data push statistics in writer

### Why are the changes needed?

Sometimes we found some jobs are slow due to the underlying one server slow, but under the current codebase, it's hard to found it. This PR is to track the shuffle-servers speed to output.

BTW, based on this PR, I will introduce the uniffle spark UI for easier and better observability.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Internal tests.
