### PR TITLE
[#2455] feat(server): add a new WaterMark for triggering flush

### DIFF
--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServerConf.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServerConf.java
@@ -364,7 +364,18 @@ public class ShuffleServerConf extends RssBaseConf {
               ConfigUtils.PERCENTAGE_DOUBLE_VALIDATOR,
               "The highWaterMark for memory percentage must be between 0.0 and 100.0")
           .defaultValue(75.0)
-          .withDescription("HighWaterMark of memory in percentage style");
+          .withDescription("HighWaterMark of memory in percentage style. When this watermark is reached,"
+              + " the thread receiving data will be blocked");
+
+  public static final ConfigOption<Double> SERVER_MEMORY_SHUFFLE_FLUSHWATERMARK_PERCENTAGE =
+      ConfigOptions.key("rss.server.memory.shuffle.flushWaterMark.percentage")
+          .doubleType()
+          .checkValue(
+              ConfigUtils.PERCENTAGE_DOUBLE_VALIDATOR,
+              "The flushWaterMark for memory percentage must be between 0.0 and 100.0")
+          .defaultValue(65.0)
+          .withDescription("FLushWaterMark of memory in percentage style. When this watermark is reached,"
+              + " the thread receiving data will not be blocked");
 
   public static final ConfigOption<Long> FLUSH_COLD_STORAGE_THRESHOLD_SIZE =
       ConfigOptions.key("rss.server.flush.cold.storage.threshold.size")

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServerConf.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServerConf.java
@@ -364,8 +364,9 @@ public class ShuffleServerConf extends RssBaseConf {
               ConfigUtils.PERCENTAGE_DOUBLE_VALIDATOR,
               "The highWaterMark for memory percentage must be between 0.0 and 100.0")
           .defaultValue(75.0)
-          .withDescription("HighWaterMark of memory in percentage style. When this watermark is reached,"
-              + " the thread receiving data will be blocked");
+          .withDescription(
+              "HighWaterMark of memory in percentage style. When this watermark is reached,"
+                  + " the thread receiving data will be blocked");
 
   public static final ConfigOption<Double> SERVER_MEMORY_SHUFFLE_FLUSHWATERMARK_PERCENTAGE =
       ConfigOptions.key("rss.server.memory.shuffle.flushWaterMark.percentage")
@@ -374,8 +375,9 @@ public class ShuffleServerConf extends RssBaseConf {
               ConfigUtils.PERCENTAGE_DOUBLE_VALIDATOR,
               "The flushWaterMark for memory percentage must be between 0.0 and 100.0")
           .defaultValue(65.0)
-          .withDescription("FLushWaterMark of memory in percentage style. When this watermark is reached,"
-              + " the thread receiving data will not be blocked");
+          .withDescription(
+              "FLushWaterMark of memory in percentage style. When this watermark is reached,"
+                  + " the thread receiving data will not be blocked");
 
   public static final ConfigOption<Long> FLUSH_COLD_STORAGE_THRESHOLD_SIZE =
       ConfigOptions.key("rss.server.flush.cold.storage.threshold.size")

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleTaskManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleTaskManager.java
@@ -1056,9 +1056,7 @@ public class ShuffleTaskManager {
   }
 
   private void triggerFlush() {
-    synchronized (this.shuffleBufferManager) {
-      this.shuffleBufferManager.flushIfNecessary();
-    }
+    this.shuffleBufferManager.flushIfFlushWaterMarkReached();
   }
 
   public Map<String, ShuffleTaskInfo> getShuffleTaskInfos() {

--- a/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferManager.java
@@ -74,7 +74,6 @@ public class ShuffleBufferManager {
   private long highWaterMark;
   private long flushWaterMark;
   private long lowWaterMark;
-
   private boolean bufferFlushEnabled;
   private long bufferFlushThreshold;
   private long bufferFlushBlocksNumThreshold;
@@ -308,9 +307,7 @@ public class ShuffleBufferManager {
         spd.getPartitionId(),
         entry.getKey().lowerEndpoint(),
         entry.getKey().upperEndpoint());
-
     flushIfHighWaterMarkReached();
-
     return StatusCode.SUCCESS;
   }
 

--- a/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferManager.java
@@ -214,7 +214,7 @@ public class ShuffleBufferManager {
                     (capacity
                         / 100.0
                         * conf.get(
-                        ShuffleServerConf.SERVER_MEMORY_SHUFFLE_FLUSHWATERMARK_PERCENTAGE));
+                            ShuffleServerConf.SERVER_MEMORY_SHUFFLE_FLUSHWATERMARK_PERCENTAGE));
           }
           if (changedProperties.contains(
               ShuffleServerConf.SERVER_MEMORY_SHUFFLE_LOWWATERMARK_PERCENTAGE.key())) {
@@ -311,7 +311,7 @@ public class ShuffleBufferManager {
 
     flushIfHighWaterMarkReached();
 
-return StatusCode.SUCCESS;
+    return StatusCode.SUCCESS;
   }
 
   private void updateShuffleSize(String appId, int shuffleId, long size) {
@@ -397,8 +397,6 @@ return StatusCode.SUCCESS;
         flushBuffer(buffer, appId, shuffleId, startPartition, endPartition, isHugePartition);
       }
     }
-
-
   }
 
   private boolean shouldTriggerFLush(long triggerWaterMark) {

--- a/server/src/test/java/org/apache/uniffle/server/buffer/ShuffleBufferManagerTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/buffer/ShuffleBufferManagerTest.java
@@ -404,7 +404,7 @@ public class ShuffleBufferManagerTest extends BufferTestBase {
     shuffleBufferManager.cacheShuffleData(appId, shuffleId, true, createData(0, 400));
     shuffleBufferManager.releasePreAllocatedSize(432);
     // trigger flush manually
-    shuffleBufferManager.flushIfNecessary();
+    shuffleBufferManager.flushIfHighWaterMarkReached();
     assertEquals(StatusCode.SUCCESS, sc);
     assertEquals(500, shuffleBufferManager.getUsedMemory());
     assertEquals(20, shuffleBufferManager.getPreAllocatedSize());


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#123] feat(server,coordinator): support xxx"
     - "[#123] feat(common): support xxx"
     - "[MINOR] improvement(script): fix style"
     - "[MINOR] improvement(ci): add some examples and notice"
     - "[#233] fix: check null before access result in xxx"
     - "[#233][FOLLOWUP] improvement(dashboard): display something xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?
<!--
(Please outline the changes and how this PR fixes the issue.)
-->
1. Add a new WaterMark for triggering flush
2. Reduce lock usage when receiving data
### Why are the changes needed?
<!--
(Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  3. If you fix a bug, describe the bug.)

Fix: # (issue)
-->
For better performance
Fix: #2455

### Does this PR introduce _any_ user-facing change?
<!--
(Please list the user-facing changes introduced by your change, including
  1. Change in user-facing APIs.
  2. Addition or removal of property keys.)
-->
set `rss.server.memory.shuffle.flushWaterMark.percentage`, default value is 65
set `rss.server.shuffleBufferManager.trigger.flush.interval` bigger than 0

### How was this patch tested?
<!--
(Please test your changes, and provide instructions on how to test it:
  1. If you add a feature or fix a bug, add a test to cover your changes. 
  2. If you fix a flaky test, repeat it for many times to prove it works.)
-->
Verify in production environment