### PR TITLE
[#2460] feat(spark)(part-2): Add support of history server plugin

### DIFF
--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/RssSparkShuffleUtils.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/RssSparkShuffleUtils.java
@@ -395,7 +395,7 @@ public class RssSparkShuffleUtils {
   }
 
   public static boolean isSparkUIEnabled(SparkConf conf) {
-    String rawPlugins = conf.get("spark.plugins");
+    String rawPlugins = conf.get("spark.plugins", null);
     if (StringUtils.isEmpty(rawPlugins)) {
       return false;
     }

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/RssSparkShuffleUtils.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/RssSparkShuffleUtils.java
@@ -393,4 +393,15 @@ public class RssSparkShuffleUtils {
     }
     return rssFetchFailedException;
   }
+
+  public static boolean isSparkUIEnabled(SparkConf conf) {
+    String rawPlugins = conf.get("spark.plugins");
+    if (StringUtils.isEmpty(rawPlugins)) {
+      return false;
+    }
+    if (rawPlugins.contains("UnifflePlugin")) {
+      return true;
+    }
+    return false;
+  }
 }

--- a/client-spark/common/src/main/java/org/apache/uniffle/shuffle/manager/RssShuffleManagerBase.java
+++ b/client-spark/common/src/main/java/org/apache/uniffle/shuffle/manager/RssShuffleManagerBase.java
@@ -107,6 +107,7 @@ import static org.apache.spark.shuffle.RssSparkConfig.RSS_BLOCK_ID_SELF_MANAGEME
 import static org.apache.spark.shuffle.RssSparkConfig.RSS_PARTITION_REASSIGN_MAX_REASSIGNMENT_SERVER_NUM;
 import static org.apache.spark.shuffle.RssSparkConfig.RSS_RESUBMIT_STAGE_WITH_FETCH_FAILURE_ENABLED;
 import static org.apache.spark.shuffle.RssSparkConfig.RSS_RESUBMIT_STAGE_WITH_WRITE_FAILURE_ENABLED;
+import static org.apache.spark.shuffle.RssSparkShuffleUtils.isSparkUIEnabled;
 import static org.apache.uniffle.common.config.RssBaseConf.RPC_SERVER_PORT;
 import static org.apache.uniffle.common.config.RssClientConf.HADOOP_CONFIG_KEY_PREFIX;
 import static org.apache.uniffle.common.config.RssClientConf.MAX_CONCURRENCY_PER_PARTITION_TO_WRITE;
@@ -283,7 +284,10 @@ public abstract class RssShuffleManagerBase implements RssShuffleManagerInterfac
     }
     this.blockIdSelfManagedEnabled = rssConf.getBoolean(RSS_BLOCK_ID_SELF_MANAGEMENT_ENABLED);
     this.shuffleManagerRpcServiceEnabled =
-        partitionReassignEnabled || rssStageRetryEnabled || blockIdSelfManagedEnabled;
+        partitionReassignEnabled
+            || rssStageRetryEnabled
+            || blockIdSelfManagedEnabled
+            || isSparkUIEnabled(conf);
 
     if (isDriver) {
       heartBeatScheduledExecutorService =

--- a/client-spark/extension/pom.xml
+++ b/client-spark/extension/pom.xml
@@ -75,7 +75,7 @@
             <plugin>
                 <groupId>net.alchim31.maven</groupId>
                 <artifactId>scala-maven-plugin</artifactId>
-                <version>3.2.2</version>
+                <version>${scala.maven.plugin.version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/client-spark/extension/src/main/resources/META-INF/services/org.apache.spark.status.AppHistoryServerPlugin
+++ b/client-spark/extension/src/main/resources/META-INF/services/org.apache.spark.status.AppHistoryServerPlugin
@@ -1,0 +1,1 @@
+org.apache.spark.UniffleHistoryServerPlugin

--- a/client-spark/extension/src/main/scala/org/apache/spark/UniffleHistoryServerPlugin.scala
+++ b/client-spark/extension/src/main/scala/org/apache/spark/UniffleHistoryServerPlugin.scala
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark
+
+import org.apache.spark.scheduler.SparkListener
+import org.apache.spark.status.{AppHistoryServerPlugin, ElementTrackingStore}
+import org.apache.spark.ui.{ShuffleTab, SparkUI}
+
+class UniffleHistoryServerPlugin extends AppHistoryServerPlugin {
+
+  override def createListeners(conf: SparkConf, store: ElementTrackingStore): Seq[SparkListener] = {
+    Seq(new UniffleListener(conf, store))
+  }
+
+  override def setupUI(ui: SparkUI): Unit = {
+    val store = new UniffleStatusStore(ui.store.store)
+    new ShuffleTab(
+      store,
+      ui
+    )
+  }
+}

--- a/client-spark/extension/src/main/scala/org/apache/spark/UniffleListener.scala
+++ b/client-spark/extension/src/main/scala/org/apache/spark/UniffleListener.scala
@@ -18,12 +18,43 @@
 package org.apache.spark
 
 import org.apache.spark.internal.Logging
-import org.apache.spark.scheduler.{SparkListener, SparkListenerEvent}
+import org.apache.spark.scheduler.{SparkListener, SparkListenerEvent, SparkListenerJobEnd, SparkListenerTaskEnd}
 import org.apache.spark.shuffle.events.{ShuffleAssignmentInfoEvent, TaskShuffleReadInfoEvent, TaskShuffleWriteInfoEvent}
 import org.apache.spark.status.ElementTrackingStore
 
+import java.util.concurrent.ConcurrentHashMap
+import scala.collection.JavaConverters.mapAsScalaMapConverter
+
 class UniffleListener(conf: SparkConf, kvstore: ElementTrackingStore)
   extends SparkListener with Logging {
+
+  private val aggregatedShuffleWriteMetric = new ConcurrentHashMap[String, AggregatedShuffleWriteMetric]
+  private val aggregatedShuffleReadMetric = new ConcurrentHashMap[String, AggregatedShuffleReadMetric]
+
+  private val updateIntervalMillis = 5000
+  private var updateLastTimeMillis: Long = -1
+
+  // Using the async interval update to reduce state store pressure
+  private def mayUpdate(force: Boolean): Unit = {
+    val now = System.currentTimeMillis()
+    if (force || now - updateLastTimeMillis > updateIntervalMillis) {
+      updateLastTimeMillis = now
+      kvstore.write(
+        new AggregatedShuffleWriteMetricsUIData(this.aggregatedShuffleWriteMetric)
+      )
+      kvstore.write(
+        new AggregatedShuffleReadMetricsUIData(this.aggregatedShuffleReadMetric)
+      )
+    }
+  }
+
+  override def onTaskEnd(taskEnd: SparkListenerTaskEnd): Unit = {
+    this.mayUpdate(false)
+  }
+
+  override def onJobEnd(jobEnd: SparkListenerJobEnd): Unit = {
+    this.mayUpdate(true)
+  }
 
   private def onBuildInfo(event: BuildInfoEvent): Unit = {
     val uiData = new BuildInfoUIData(event.info.toSeq.sortBy(_._1))
@@ -40,25 +71,24 @@ class UniffleListener(conf: SparkConf, kvstore: ElementTrackingStore)
   }
 
   private def onTaskShuffleWriteInfo(event: TaskShuffleWriteInfoEvent): Unit = {
-    kvstore.write(
-      new TaskShuffleWriteMetricUIData(
-        event.getStageId,
-        event.getShuffleId,
-        event.getTaskId,
-        event.getMetrics
-      )
-    )
+    val metrics = event.getMetrics
+    for (metric <- metrics.asScala) {
+      val id = metric._1
+      val agg_metric = this.aggregatedShuffleWriteMetric.computeIfAbsent(id, _ => new AggregatedShuffleWriteMetric(0, 0))
+      agg_metric.byteSize += metric._2.getByteSize
+      agg_metric.durationMillis += metric._2.getDurationMillis
+
+    }
   }
 
   private def onTaskShuffleReadInfo(event: TaskShuffleReadInfoEvent): Unit = {
-    kvstore.write(
-      new TaskShuffleReadMetricUIData(
-        event.getStageId,
-        event.getShuffleId,
-        event.getTaskId,
-        event.getMetrics
-      )
-    )
+    val metrics = event.getMetrics
+    for (metric <- metrics.asScala) {
+      val id = metric._1
+      val agg_metric = this.aggregatedShuffleReadMetric.computeIfAbsent(id, _ => new AggregatedShuffleReadMetric(0, 0))
+      agg_metric.byteSize += metric._2.getByteSize
+      agg_metric.durationMillis += metric._2.getDurationMillis
+    }
   }
 
   override def onOtherEvent(event: SparkListenerEvent): Unit = event match {

--- a/client-spark/extension/src/main/scala/org/apache/spark/UnifflePlugin.scala
+++ b/client-spark/extension/src/main/scala/org/apache/spark/UnifflePlugin.scala
@@ -37,6 +37,7 @@ private class UniffleDriverPlugin extends DriverPlugin with Logging {
   private var _sc: Option[SparkContext] = None
 
   override def init(sc: SparkContext, pluginContext: PluginContext): java.util.Map[String, String] = {
+    logInfo("Initializing UniffleDriverPlugin...")
     _sc = Some(sc)
     UniffleListener.register(sc)
     postBuildInfoEvent(sc)
@@ -56,7 +57,7 @@ private class UniffleDriverPlugin extends DriverPlugin with Logging {
     buildInfo.put("Commit Id", ProjectConstants.getGitCommitId)
     buildInfo.put("Revision", ProjectConstants.REVISION)
 
-    val event = new BuildInfoEvent(buildInfo.toMap)
+    val event = BuildInfoEvent(buildInfo.toMap)
     context.listenerBus.post(event)
   }
 }

--- a/client-spark/extension/src/main/scala/org/apache/spark/UniffleStatusStore.scala
+++ b/client-spark/extension/src/main/scala/org/apache/spark/UniffleStatusStore.scala
@@ -68,7 +68,7 @@ class UniffleStatusStore(store: KVStore) {
     try {
       store.read(kClass, kClass.getName)
     } catch {
-      case _: NoSuchElementException => TotalTaskCpuTime(0)
+      case _: Exception => TotalTaskCpuTime(0)
     }
   }
 }

--- a/client-spark/extension/src/main/scala/org/apache/spark/UniffleStatusStore.scala
+++ b/client-spark/extension/src/main/scala/org/apache/spark/UniffleStatusStore.scala
@@ -18,11 +18,11 @@
 package org.apache.spark
 
 import com.fasterxml.jackson.annotation.JsonIgnore
-import org.apache.spark.shuffle.events.{ShuffleReadMetric, ShuffleWriteMetric}
 import org.apache.spark.status.KVUtils.KVIndexParam
 import org.apache.spark.util.Utils
 import org.apache.spark.util.kvstore.{KVIndex, KVStore, KVStoreView}
 
+import java.util.concurrent.ConcurrentHashMap
 import scala.collection.JavaConverters.asScalaIteratorConverter
 
 class UniffleStatusStore(store: KVStore) {
@@ -32,19 +32,35 @@ class UniffleStatusStore(store: KVStore) {
 
   def buildInfo(): BuildInfoUIData = {
     val kClass = classOf[BuildInfoUIData]
-    store.read(kClass, kClass.getName)
-  }
-
-  def taskShuffleReadMetrics(): Seq[TaskShuffleReadMetricUIData] = {
-    viewToSeq(store.view(classOf[TaskShuffleReadMetricUIData]))
-  }
-
-  def taskShuffleWriteMetrics(): Seq[TaskShuffleWriteMetricUIData] = {
-    viewToSeq(store.view(classOf[TaskShuffleWriteMetricUIData]))
+    try {
+      store.read(kClass, kClass.getName)
+    } catch {
+      case _: NoSuchElementException => new BuildInfoUIData(Seq.empty)
+    }
   }
 
   def assignmentInfos(): Seq[ShuffleAssignmentUIData] = {
     viewToSeq(store.view(classOf[ShuffleAssignmentUIData]))
+  }
+
+  def aggregatedShuffleWriteMetrics(): AggregatedShuffleWriteMetricsUIData = {
+    val kClass = classOf[AggregatedShuffleWriteMetricsUIData]
+    try {
+      store.read(kClass, kClass.getName)
+    } catch {
+      case _: NoSuchElementException =>
+        new AggregatedShuffleWriteMetricsUIData(new ConcurrentHashMap[String, AggregatedShuffleWriteMetric]())
+    }
+  }
+
+  def aggregatedShuffleReadMetrics(): AggregatedShuffleReadMetricsUIData = {
+    val kClass = classOf[AggregatedShuffleReadMetricsUIData]
+    try {
+      store.read(kClass, kClass.getName)
+    } catch {
+      case _: NoSuchElementException =>
+        new AggregatedShuffleReadMetricsUIData(new ConcurrentHashMap[String, AggregatedShuffleReadMetric]())
+    }
   }
 }
 
@@ -54,14 +70,24 @@ class BuildInfoUIData(val info: Seq[(String, String)]) {
   def id: String = classOf[BuildInfoUIData].getName()
 }
 
-class TaskShuffleWriteMetricUIData(val stageId: Int,
-                                   val shuffleId: Int,
-                                   @KVIndexParam val taskId: Long,
-                                   val metrics: java.util.Map[String, ShuffleWriteMetric])
-
-class TaskShuffleReadMetricUIData(val stageId: Int,
-                                  val shuffleId: Int,
-                                  @KVIndexParam val taskId: Long,
-                                  val metrics: java.util.Map[String, ShuffleReadMetric])
 class ShuffleAssignmentUIData(@KVIndexParam val shuffleId: Int,
                               val shuffleServerIdList: java.util.List[String])
+
+// Aggregated shuffle write/read metrics
+class AggregatedShuffleMetric(var durationMillis: Long, var byteSize: Long)
+
+class AggregatedShuffleWriteMetricsUIData(val metrics: ConcurrentHashMap[String, AggregatedShuffleWriteMetric]) {
+  @JsonIgnore
+  @KVIndex
+  def id: String = classOf[AggregatedShuffleWriteMetricsUIData].getName()
+}
+class AggregatedShuffleWriteMetric(durationMillis: Long, byteSize: Long)
+  extends AggregatedShuffleMetric(durationMillis, byteSize)
+
+class AggregatedShuffleReadMetricsUIData(val metrics: ConcurrentHashMap[String, AggregatedShuffleReadMetric]) {
+  @JsonIgnore
+  @KVIndex
+  def id: String = classOf[AggregatedShuffleReadMetricsUIData].getName()
+}
+class AggregatedShuffleReadMetric(durationMillis: Long, byteSize: Long)
+  extends AggregatedShuffleMetric(durationMillis, byteSize)

--- a/client-spark/extension/src/main/scala/org/apache/spark/UniffleStatusStore.scala
+++ b/client-spark/extension/src/main/scala/org/apache/spark/UniffleStatusStore.scala
@@ -62,6 +62,15 @@ class UniffleStatusStore(store: KVStore) {
         new AggregatedShuffleReadMetricsUIData(new ConcurrentHashMap[String, AggregatedShuffleReadMetric]())
     }
   }
+
+  def totalTaskTime(): TotalTaskCpuTime = {
+    val kClass = classOf[TotalTaskCpuTime]
+    try {
+      store.read(kClass, kClass.getName)
+    } catch {
+      case _: NoSuchElementException => TotalTaskCpuTime(0)
+    }
+  }
 }
 
 class BuildInfoUIData(val info: Seq[(String, String)]) {
@@ -91,3 +100,10 @@ class AggregatedShuffleReadMetricsUIData(val metrics: ConcurrentHashMap[String, 
 }
 class AggregatedShuffleReadMetric(durationMillis: Long, byteSize: Long)
   extends AggregatedShuffleMetric(durationMillis, byteSize)
+
+// task total cpu time
+case class TotalTaskCpuTime(durationMillis: Long) {
+  @JsonIgnore
+  @KVIndex
+  def id: String = classOf[TotalTaskCpuTime].getName()
+}

--- a/client-spark/extension/src/main/scala/org/apache/spark/ui/ShufflePage.scala
+++ b/client-spark/extension/src/main/scala/org/apache/spark/ui/ShufflePage.scala
@@ -250,10 +250,10 @@ class ShufflePage(parent: ShuffleTab) extends WebUIPage("") with Logging {
         serverId,
         UIUtils.formatNumber(writeMetric._1),
         UIUtils.formatDuration(writeMetric._2),
-        writeMetric._3,
+        roundToTwoDecimals(writeMetric._3),
         UIUtils.formatNumber(readMetric._1),
         UIUtils.formatDuration(readMetric._2),
-        readMetric._3
+        roundToTwoDecimals(readMetric._3)
       )
     }
     unionMetrics

--- a/client-spark/extension/src/main/scala/org/apache/spark/ui/ShufflePage.scala
+++ b/client-spark/extension/src/main/scala/org/apache/spark/ui/ShufflePage.scala
@@ -86,7 +86,7 @@ class ShufflePage(parent: ShuffleTab) extends WebUIPage("") with Logging {
     val shuffleTotalSize = writeMetaInfo._1
     val shuffleTotalTime = writeMetaInfo._2 + readMetaInfo._2
     val taskCpuTime = runtimeStatusStore.totalTaskTime
-    val percent = if (taskCpuTime == 0) 0 else shuffleTotalTime.toDouble / taskCpuTime.durationMillis
+    val percent = if (taskCpuTime == null || taskCpuTime == 0) 0 else shuffleTotalTime.toDouble / taskCpuTime.durationMillis
 
     // render build info
     val buildInfo = runtimeStatusStore.buildInfo()

--- a/client-spark/extension/src/main/scala/org/apache/spark/ui/ShufflePage.scala
+++ b/client-spark/extension/src/main/scala/org/apache/spark/ui/ShufflePage.scala
@@ -85,8 +85,8 @@ class ShufflePage(parent: ShuffleTab) extends WebUIPage("") with Logging {
     val readMetaInfo = getShuffleMetaInfo(originReadMetric.metrics.asScala.toSeq)
     val shuffleTotalSize = writeMetaInfo._1
     val shuffleTotalTime = writeMetaInfo._2 + readMetaInfo._2
-    val taskCpuTime = runtimeStatusStore.totalTaskTime
-    val percent = if (taskCpuTime == null || taskCpuTime == 0) 0 else shuffleTotalTime.toDouble / taskCpuTime.durationMillis
+    val taskCpuTime = if (runtimeStatusStore.totalTaskTime == null) 0 else runtimeStatusStore.totalTaskTime.durationMillis
+    val percent = if (taskCpuTime == 0) 0 else shuffleTotalTime.toDouble / taskCpuTime
 
     // render build info
     val buildInfo = runtimeStatusStore.buildInfo()
@@ -150,7 +150,7 @@ class ShufflePage(parent: ShuffleTab) extends WebUIPage("") with Logging {
             <a>
               <strong>Shuffle Duration / Task Duration:</strong>
             </a>
-            {UIUtils.formatDuration(shuffleTotalTime)} / {UIUtils.formatDuration(taskCpuTime.durationMillis)} = {roundToTwoDecimals(percent)}
+            {UIUtils.formatDuration(shuffleTotalTime)} / {UIUtils.formatDuration(taskCpuTime)} = {roundToTwoDecimals(percent)}
           </li>
           </ul>
         </div>

--- a/client-spark/extension/src/main/scala/org/apache/spark/ui/ShufflePage.scala
+++ b/client-spark/extension/src/main/scala/org/apache/spark/ui/ShufflePage.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.ui
 
 import org.apache.spark.internal.Logging
+import org.apache.spark.util.Utils
 import org.apache.spark.{AggregatedShuffleMetric, AggregatedShuffleReadMetric, AggregatedShuffleWriteMetric}
 
 import java.util.concurrent.ConcurrentHashMap
@@ -82,7 +83,7 @@ class ShufflePage(parent: ShuffleTab) extends WebUIPage("") with Logging {
     // render header
     val writeMetaInfo = getShuffleMetaInfo(originWriteMetric.metrics.asScala.toSeq)
     val readMetaInfo = getShuffleMetaInfo(originReadMetric.metrics.asScala.toSeq)
-    val shuffleTotalSize = readMetaInfo._1
+    val shuffleTotalSize = writeMetaInfo._1
     val shuffleTotalTime = writeMetaInfo._2 + readMetaInfo._2
     val taskCpuTime = runtimeStatusStore.totalTaskTime
     val percent = if (taskCpuTime == 0) 0 else shuffleTotalTime.toDouble / taskCpuTime.durationMillis
@@ -144,7 +145,7 @@ class ShufflePage(parent: ShuffleTab) extends WebUIPage("") with Logging {
               <a>
                 <strong>Total shuffle bytes:</strong>
               </a>
-              {UIUtils.formatNumber(shuffleTotalSize)}
+              {Utils.bytesToString(shuffleTotalSize)}
             </li><li data-relingo-block="true">
             <a>
               <strong>Shuffle Duration / Task Duration:</strong>
@@ -248,10 +249,10 @@ class ShufflePage(parent: ShuffleTab) extends WebUIPage("") with Logging {
       val readMetric = readMetricsToMap.getOrElse(serverId, (0L, 0L, 0.00))
       (
         serverId,
-        UIUtils.formatNumber(writeMetric._1),
+        Utils.bytesToString(writeMetric._1),
         UIUtils.formatDuration(writeMetric._2),
         roundToTwoDecimals(writeMetric._3),
-        UIUtils.formatNumber(readMetric._1),
+        Utils.bytesToString(readMetric._1),
         UIUtils.formatDuration(readMetric._2),
         roundToTwoDecimals(readMetric._3)
       )

--- a/client-spark/extension/src/main/scala/org/apache/spark/ui/ShufflePage.scala
+++ b/client-spark/extension/src/main/scala/org/apache/spark/ui/ShufflePage.scala
@@ -145,7 +145,7 @@ class ShufflePage(parent: ShuffleTab) extends WebUIPage("") with Logging {
               <a>
                 <strong>Total shuffle bytes:</strong>
               </a>
-              {Utils.bytesToString(shuffleTotalSize)}
+              {shuffleTotalSize} / {Utils.bytesToString(shuffleTotalSize)}
             </li><li data-relingo-block="true">
             <a>
               <strong>Shuffle Duration / Task Duration:</strong>

--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,7 @@
     <snakeyaml.version>2.2</snakeyaml.version>
     <kryo.version>4.0.2</kryo.version>
     <scala.version>2.12.18</scala.version>
+    <scala.maven.plugin.version>3.2.2</scala.maven.plugin.version>
   </properties>
 
   <repositories>


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. Add support of history server plugin
2. Optimize UI performance by more memory cache and less status store access
3. Add more infos and correct partial metric unit show 
4. Enable shuffle manager rpc when UI plugin is enabled

### Why are the changes needed?

followup for #2459 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Internal tests.

![image](https://github.com/user-attachments/assets/6cb89fa1-27ab-428f-a09c-c6d32b184f59)

