### PR TITLE
[#2480] fix: The failure of the reporting block led to an abnormal backward shift

### DIFF
--- a/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
@@ -811,6 +811,8 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
           throw new RssSendFailedException(
               "Throw an exception because the report shuffle result status code is not SUCCESS.");
         }
+        throw new RssSendFailedException(
+            "Throw an exception because the report shuffle result status code is not SUCCESS.", e);
       }
     }
     if (blockReportTracker.values().stream().anyMatch(cnt -> cnt < replicaWrite)) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

After writing the data block, all the block metadata will be reported to the Shuffle Server. However, in reportShuffleResult, when handling exceptions, only an alarm log is recorded.
I met some online abnormalities, thread is interrupted when reporting block of metadata, may be because of a timeout, then the APP normal execution, when get the Read end block of metadata, getShuffleResult or getShuffleResultForMultiPart method will have check metadata, At this point, due to inconsistent block metadata, an exception was thrown, masking the true cause of the error.

### Why are the changes needed?

Fix: #2480

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

UT.
