### PR TITLE
[#2503] fix(spark): Skip reassignment number check on partition split

### DIFF
--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/handle/MutableShuffleHandleInfo.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/handle/MutableShuffleHandleInfo.java
@@ -280,6 +280,11 @@ public class MutableShuffleHandleInfo extends ShuffleHandleInfoBase {
   public void checkPartitionReassignServerNum(
       Set<Integer> partitionIds, int legalReassignServerNum) {
     for (int partitionId : partitionIds) {
+      // skip the split partition id. Some tasks may reassign without partition split tag,
+      // but this partition may have been split.
+      if (isPartitionSplit(partitionId)) {
+        continue;
+      }
       Map<Integer, List<ShuffleServerInfo>> replicas =
           partitionReplicaAssignedServers.get(partitionId);
       for (List<ShuffleServerInfo> servers : replicas.values()) {
@@ -402,5 +407,9 @@ public class MutableShuffleHandleInfo extends ShuffleHandleInfoBase {
     return excludedServerForPartitionToReplacements
         .getOrDefault(partitionId, Collections.emptyMap())
         .keySet();
+  }
+
+  public boolean isPartitionSplit(int partitionId) {
+    return excludedServerForPartitionToReplacements.containsKey(partitionId);
   }
 }

--- a/client-spark/common/src/main/java/org/apache/uniffle/shuffle/manager/RssShuffleManagerBase.java
+++ b/client-spark/common/src/main/java/org/apache/uniffle/shuffle/manager/RssShuffleManagerBase.java
@@ -1041,7 +1041,7 @@ public abstract class RssShuffleManagerBase implements RssShuffleManagerInterfac
           boolean serverHasReplaced = false;
 
           Set<ShuffleServerInfo> updatedReassignServers;
-          if (!partitionSplit) {
+          if (!partitionSplit && !internalHandle.isPartitionSplit(partitionId)) {
             Set<ShuffleServerInfo> replacements = internalHandle.getReplacements(serverId);
             if (CollectionUtils.isEmpty(replacements)) {
               replacements =


### PR DESCRIPTION
### What changes were proposed in this pull request?

Skip reassignment number check on partition split and reuse the assigned server for split partition

### Why are the changes needed?

fix #2503

![image](https://github.com/user-attachments/assets/153da590-40f4-4915-adcb-22ac1e9b38a6)

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Internal job test
