### PR TITLE
[#2508] feat(spark3): Record failed tasks on any shuffle write/failure into event logs

### DIFF
--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/events/TaskShuffleReadInfoEvent.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/events/TaskShuffleReadInfoEvent.java
@@ -24,13 +24,22 @@ public class TaskShuffleReadInfoEvent extends UniffleEvent {
   private int shuffleId;
   private long taskId;
   private Map<String, ShuffleReadMetric> metrics;
+  private boolean isShuffleReadFailed;
+  private String failureReason;
 
   public TaskShuffleReadInfoEvent(
-      int stageId, int shuffleId, long taskId, Map<String, ShuffleReadMetric> metrics) {
+      int stageId,
+      int shuffleId,
+      long taskId,
+      Map<String, ShuffleReadMetric> metrics,
+      boolean isShuffleReadFailed,
+      String failureReason) {
     this.stageId = stageId;
     this.shuffleId = shuffleId;
     this.taskId = taskId;
     this.metrics = metrics;
+    this.isShuffleReadFailed = isShuffleReadFailed;
+    this.failureReason = failureReason;
   }
 
   public int getStageId() {

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/events/TaskShuffleReadInfoEvent.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/events/TaskShuffleReadInfoEvent.java
@@ -57,4 +57,12 @@ public class TaskShuffleReadInfoEvent extends UniffleEvent {
   public Map<String, ShuffleReadMetric> getMetrics() {
     return metrics;
   }
+
+  public boolean isShuffleReadFailed() {
+    return isShuffleReadFailed;
+  }
+
+  public String getFailureReason() {
+    return failureReason;
+  }
 }

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/events/TaskShuffleWriteInfoEvent.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/events/TaskShuffleWriteInfoEvent.java
@@ -25,18 +25,24 @@ public class TaskShuffleWriteInfoEvent extends UniffleEvent {
   private long taskId;
   private Map<String, ShuffleWriteMetric> metrics;
   private ShuffleWriteTimes writeTimes;
+  private boolean isShuffleWriteFailed;
+  private String failureReason;
 
   public TaskShuffleWriteInfoEvent(
       int stageId,
       int shuffleId,
       long taskId,
       Map<String, ShuffleWriteMetric> metrics,
-      ShuffleWriteTimes writeTimes) {
+      ShuffleWriteTimes writeTimes,
+      boolean isShuffleWriteFailed,
+      String failureReason) {
     this.stageId = stageId;
     this.shuffleId = shuffleId;
     this.taskId = taskId;
     this.metrics = metrics;
     this.writeTimes = writeTimes;
+    this.isShuffleWriteFailed = isShuffleWriteFailed;
+    this.failureReason = failureReason;
   }
 
   public int getStageId() {
@@ -57,5 +63,13 @@ public class TaskShuffleWriteInfoEvent extends UniffleEvent {
 
   public ShuffleWriteTimes getWriteTimes() {
     return writeTimes;
+  }
+
+  public boolean isShuffleWriteFailed() {
+    return isShuffleWriteFailed;
+  }
+
+  public String getFailureReason() {
+    return failureReason;
   }
 }

--- a/client-spark/common/src/main/java/org/apache/uniffle/shuffle/manager/ShuffleManagerGrpcService.java
+++ b/client-spark/common/src/main/java/org/apache/uniffle/shuffle/manager/ShuffleManagerGrpcService.java
@@ -732,7 +732,7 @@ public class ShuffleManagerGrpcService extends ShuffleManagerImplBase {
                     Collectors.toMap(
                         Map.Entry::getKey, x -> ShuffleWriteMetric.from(x.getValue()))),
             ShuffleWriteTimes.fromProto(request.getShuffleWriteTimes()),
-            request.getIsShuffleWriteFailed(),
+            request.getIsTaskWriteFailed(),
             request.getShuffleWriteFailureReason());
     RssSparkShuffleUtils.getActiveSparkContext().listenerBus().post(event);
     RssProtos.ReportShuffleWriteMetricResponse reply =
@@ -766,7 +766,7 @@ public class ShuffleManagerGrpcService extends ShuffleManagerImplBase {
                                 x.getValue().getLocalfileByteSize(),
                                 x.getValue().getHadoopDurationMillis(),
                                 x.getValue().getHadoopByteSize()))),
-            request.getIsShuffleReadFailed(),
+            request.getIsTaskReadFailed(),
             request.getShuffleReadFailureReason());
     RssSparkShuffleUtils.getActiveSparkContext().listenerBus().post(event);
     RssProtos.ReportShuffleReadMetricResponse reply =

--- a/client-spark/common/src/main/java/org/apache/uniffle/shuffle/manager/ShuffleManagerGrpcService.java
+++ b/client-spark/common/src/main/java/org/apache/uniffle/shuffle/manager/ShuffleManagerGrpcService.java
@@ -731,7 +731,9 @@ public class ShuffleManagerGrpcService extends ShuffleManagerImplBase {
                 .collect(
                     Collectors.toMap(
                         Map.Entry::getKey, x -> ShuffleWriteMetric.from(x.getValue()))),
-            ShuffleWriteTimes.fromProto(request.getShuffleWriteTimes()));
+            ShuffleWriteTimes.fromProto(request.getShuffleWriteTimes()),
+            request.getIsShuffleWriteFailed(),
+            request.getShuffleWriteFailureReason());
     RssSparkShuffleUtils.getActiveSparkContext().listenerBus().post(event);
     RssProtos.ReportShuffleWriteMetricResponse reply =
         RssProtos.ReportShuffleWriteMetricResponse.newBuilder()
@@ -763,7 +765,9 @@ public class ShuffleManagerGrpcService extends ShuffleManagerImplBase {
                                 x.getValue().getLocalfileDurationMillis(),
                                 x.getValue().getLocalfileByteSize(),
                                 x.getValue().getHadoopDurationMillis(),
-                                x.getValue().getHadoopByteSize()))));
+                                x.getValue().getHadoopByteSize()))),
+            request.getIsShuffleReadFailed(),
+            request.getShuffleReadFailureReason());
     RssSparkShuffleUtils.getActiveSparkContext().listenerBus().post(event);
     RssProtos.ReportShuffleReadMetricResponse reply =
         RssProtos.ReportShuffleReadMetricResponse.newBuilder()

--- a/internal-client/src/main/java/org/apache/uniffle/client/request/RssReportShuffleReadMetricRequest.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/request/RssReportShuffleReadMetricRequest.java
@@ -18,6 +18,7 @@
 package org.apache.uniffle.client.request;
 
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.apache.uniffle.proto.RssProtos;
@@ -27,13 +28,22 @@ public class RssReportShuffleReadMetricRequest {
   private int shuffleId;
   private long taskId;
   private Map<String, TaskShuffleReadMetric> metrics;
+  private boolean isShuffleReadFailed;
+  private Optional<String> shuffleReadReason;
 
   public RssReportShuffleReadMetricRequest(
-      int stageId, int shuffleId, long taskId, Map<String, TaskShuffleReadMetric> metrics) {
+      int stageId,
+      int shuffleId,
+      long taskId,
+      Map<String, TaskShuffleReadMetric> metrics,
+      boolean isShuffleReadFailed,
+      Optional<String> shuffleReadReason) {
     this.stageId = stageId;
     this.shuffleId = shuffleId;
     this.taskId = taskId;
     this.metrics = metrics;
+    this.isShuffleReadFailed = isShuffleReadFailed;
+    this.shuffleReadReason = shuffleReadReason;
   }
 
   public RssProtos.ReportShuffleReadMetricRequest toProto() {
@@ -44,6 +54,8 @@ public class RssReportShuffleReadMetricRequest {
         .setShuffleId(request.shuffleId)
         .setStageId(request.stageId)
         .setTaskId(request.taskId)
+        .setIsShuffleReadFailed(request.isShuffleReadFailed)
+        .setShuffleReadFailureReason(request.shuffleReadReason.orElse(""))
         .putAllMetrics(
             request.metrics.entrySet().stream()
                 .collect(

--- a/internal-client/src/main/java/org/apache/uniffle/client/request/RssReportShuffleReadMetricRequest.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/request/RssReportShuffleReadMetricRequest.java
@@ -54,7 +54,7 @@ public class RssReportShuffleReadMetricRequest {
         .setShuffleId(request.shuffleId)
         .setStageId(request.stageId)
         .setTaskId(request.taskId)
-        .setIsShuffleReadFailed(request.isShuffleReadFailed)
+        .setIsTaskReadFailed(request.isShuffleReadFailed)
         .setShuffleReadFailureReason(request.shuffleReadReason.orElse(""))
         .putAllMetrics(
             request.metrics.entrySet().stream()

--- a/internal-client/src/main/java/org/apache/uniffle/client/request/RssReportShuffleWriteMetricRequest.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/request/RssReportShuffleWriteMetricRequest.java
@@ -59,7 +59,7 @@ public class RssReportShuffleWriteMetricRequest {
         .setStageId(request.stageId)
         .setTaskId(request.taskId)
         .setShuffleWriteTimes(writeTimes.toProto())
-        .setIsShuffleWriteFailed(isShuffleWriteFailed)
+        .setIsTaskWriteFailed(isShuffleWriteFailed)
         .setShuffleWriteFailureReason(shuffleWriteFailureReason.orElse(""))
         .putAllMetrics(
             request.metrics.entrySet().stream()

--- a/internal-client/src/main/java/org/apache/uniffle/client/request/RssReportShuffleWriteMetricRequest.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/request/RssReportShuffleWriteMetricRequest.java
@@ -30,17 +30,24 @@ public class RssReportShuffleWriteMetricRequest {
   private Map<String, TaskShuffleWriteMetric> metrics;
   private TaskShuffleWriteTimes writeTimes;
 
+  private boolean isShuffleWriteFailed;
+  private Optional<String> shuffleWriteFailureReason;
+
   public RssReportShuffleWriteMetricRequest(
       int stageId,
       int shuffleId,
       long taskId,
       Map<String, TaskShuffleWriteMetric> metrics,
-      TaskShuffleWriteTimes writeTimes) {
+      TaskShuffleWriteTimes writeTimes,
+      boolean isShuffleWriteFailed,
+      Optional<String> shuffleWriteFailureReason) {
     this.stageId = stageId;
     this.shuffleId = shuffleId;
     this.taskId = taskId;
     this.metrics = metrics;
     this.writeTimes = writeTimes;
+    this.isShuffleWriteFailed = isShuffleWriteFailed;
+    this.shuffleWriteFailureReason = shuffleWriteFailureReason;
   }
 
   public RssProtos.ReportShuffleWriteMetricRequest toProto() {
@@ -52,6 +59,8 @@ public class RssReportShuffleWriteMetricRequest {
         .setStageId(request.stageId)
         .setTaskId(request.taskId)
         .setShuffleWriteTimes(writeTimes.toProto())
+        .setIsShuffleWriteFailed(isShuffleWriteFailed)
+        .setShuffleWriteFailureReason(shuffleWriteFailureReason.orElse(""))
         .putAllMetrics(
             request.metrics.entrySet().stream()
                 .collect(

--- a/proto/src/main/proto/Rss.proto
+++ b/proto/src/main/proto/Rss.proto
@@ -638,8 +638,8 @@ message ReportShuffleReadMetricRequest {
   int32 stageId = 2;
   int64 taskId = 3;
   map<string, ShuffleReadMetric> metrics = 4;
-  bool isShuffleReadFailed = 6;
-  string shuffleReadFailureReason = 7;
+  bool isShuffleReadFailed = 5;
+  string shuffleReadFailureReason = 6;
 }
 
 message ReportShuffleReadMetricResponse {

--- a/proto/src/main/proto/Rss.proto
+++ b/proto/src/main/proto/Rss.proto
@@ -591,6 +591,8 @@ message ReportShuffleWriteMetricRequest {
   int64 taskId = 3;
   map<string, ShuffleWriteMetric> metrics = 4;
   ShuffleWriteTimes shuffleWriteTimes = 5;
+  bool isShuffleWriteFailed = 6;
+  string shuffleWriteFailureReason = 7;
 }
 
 message ShuffleWriteTimes {
@@ -636,6 +638,8 @@ message ReportShuffleReadMetricRequest {
   int32 stageId = 2;
   int64 taskId = 3;
   map<string, ShuffleReadMetric> metrics = 4;
+  bool isShuffleReadFailed = 6;
+  string shuffleReadFailureReason = 7;
 }
 
 message ReportShuffleReadMetricResponse {

--- a/proto/src/main/proto/Rss.proto
+++ b/proto/src/main/proto/Rss.proto
@@ -591,7 +591,7 @@ message ReportShuffleWriteMetricRequest {
   int64 taskId = 3;
   map<string, ShuffleWriteMetric> metrics = 4;
   ShuffleWriteTimes shuffleWriteTimes = 5;
-  bool isShuffleWriteFailed = 6;
+  bool isTaskWriteFailed = 6;
   string shuffleWriteFailureReason = 7;
 }
 
@@ -638,7 +638,7 @@ message ReportShuffleReadMetricRequest {
   int32 stageId = 2;
   int64 taskId = 3;
   map<string, ShuffleReadMetric> metrics = 4;
-  bool isShuffleReadFailed = 5;
+  bool isTaskReadFailed = 5;
   string shuffleReadFailureReason = 6;
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Record failed tasks on any shuffle write/failure into event logs

### Why are the changes needed?

For #2508. Having this PR, we could retrieve spark jobs failure reason from the whole clusters' event logs.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Neen't