### PR TITLE
[#2502] feat(spark3): Fast fail for those stale assign blocks for partition reassign

### DIFF
--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/DataPusher.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/DataPusher.java
@@ -19,6 +19,7 @@ package org.apache.spark.shuffle.writer;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -39,7 +40,9 @@ import org.apache.uniffle.client.common.ShuffleServerPushCostTracker;
 import org.apache.uniffle.client.impl.FailedBlockSendTracker;
 import org.apache.uniffle.client.response.SendShuffleDataResult;
 import org.apache.uniffle.common.ShuffleBlockInfo;
+import org.apache.uniffle.common.ShuffleServerInfo;
 import org.apache.uniffle.common.exception.RssException;
+import org.apache.uniffle.common.rpc.StatusCode;
 import org.apache.uniffle.common.util.ThreadUtils;
 
 /**
@@ -89,13 +92,17 @@ public class DataPusher implements Closeable {
             () -> {
               String taskId = event.getTaskId();
               List<ShuffleBlockInfo> shuffleBlockInfoList = event.getShuffleDataInfoList();
+              // filter out the shuffle blocks with stale assignment
+              List<ShuffleBlockInfo> validBlocks =
+                  filterOutStaleAssignmentBlocks(taskId, shuffleBlockInfoList);
+
               SendShuffleDataResult result = null;
               try {
                 result =
                     shuffleWriteClient.sendShuffleData(
                         rssAppId,
                         event.getStageAttemptNumber(),
-                        shuffleBlockInfoList,
+                        validBlocks,
                         () -> !isValidTask(taskId));
                 putBlockId(taskToSuccessBlockIds, taskId, result.getSuccessBlockIds());
                 putFailedBlockSendTracker(
@@ -109,7 +116,7 @@ public class DataPusher implements Closeable {
                 }
 
                 Set<Long> succeedBlockIds = getSucceedBlockIds(result);
-                for (ShuffleBlockInfo block : shuffleBlockInfoList) {
+                for (ShuffleBlockInfo block : validBlocks) {
                   block.executeCompletionCallback(succeedBlockIds.contains(block.getBlockId()));
                 }
 
@@ -120,7 +127,7 @@ public class DataPusher implements Closeable {
                 }
               }
               Set<Long> succeedBlockIds = getSucceedBlockIds(result);
-              return shuffleBlockInfoList.stream()
+              return validBlocks.stream()
                   .filter(x -> succeedBlockIds.contains(x.getBlockId()))
                   .map(x -> x.getFreeMemory())
                   .reduce((a, b) -> a + b)
@@ -132,6 +139,37 @@ public class DataPusher implements Closeable {
               LOGGER.error("Unexpected exceptions occurred while sending shuffle data", ex);
               return null;
             });
+  }
+
+  /**
+   * This method is only valid for the single replica. If the block info's assignment is stale, it
+   * will be filtered out and make it retry. If the partition reassignment is disabled, this method
+   * always will not filter out any blocks.
+   *
+   * @param taskId
+   * @param blocks
+   * @return the valid shuffle blocks
+   */
+  private List<ShuffleBlockInfo> filterOutStaleAssignmentBlocks(
+      String taskId, List<ShuffleBlockInfo> blocks) {
+    FailedBlockSendTracker staleBlockTracker = new FailedBlockSendTracker();
+    List<ShuffleBlockInfo> validBlocks = new ArrayList<>();
+    for (ShuffleBlockInfo block : blocks) {
+      List<ShuffleServerInfo> servers = block.getShuffleServerInfos();
+      // skip the multi replica cases.
+      if (servers == null || servers.size() != 1) {
+        validBlocks.add(block);
+      } else {
+        if (block.isStaleAssignment()) {
+          staleBlockTracker.add(
+              block, block.getShuffleServerInfos().get(0), StatusCode.INTERNAL_ERROR);
+        } else {
+          validBlocks.add(block);
+        }
+      }
+    }
+    putFailedBlockSendTracker(taskToFailedBlockSendTracker, taskId, staleBlockTracker);
+    return validBlocks;
   }
 
   private Set<Long> getSucceedBlockIds(SendShuffleDataResult result) {
@@ -155,7 +193,7 @@ public class DataPusher implements Closeable {
       Map<String, FailedBlockSendTracker> taskToFailedBlockSendTracker,
       String taskAttemptId,
       FailedBlockSendTracker failedBlockSendTracker) {
-    if (failedBlockSendTracker == null) {
+    if (failedBlockSendTracker == null || failedBlockSendTracker.isEmpty()) {
       return;
     }
     taskToFailedBlockSendTracker

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/DataPusher.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/DataPusher.java
@@ -32,6 +32,7 @@ import java.util.concurrent.TimeUnit;
 
 import com.google.common.collect.Queues;
 import com.google.common.collect.Sets;
+import org.apache.commons.collections4.CollectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -95,6 +96,9 @@ public class DataPusher implements Closeable {
               // filter out the shuffle blocks with stale assignment
               List<ShuffleBlockInfo> validBlocks =
                   filterOutStaleAssignmentBlocks(taskId, shuffleBlockInfoList);
+              if (CollectionUtils.isEmpty(validBlocks)) {
+                return 0L;
+              }
 
               SendShuffleDataResult result = null;
               try {

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/WriteBufferManager.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/WriteBufferManager.java
@@ -448,7 +448,8 @@ public class WriteBufferManager extends MemoryConsumer {
         partitionAssignmentRetrieveFunc.apply(partitionId),
         uncompressLength,
         wb.getMemoryUsed(),
-        taskAttemptId);
+        taskAttemptId,
+        partitionAssignmentRetrieveFunc);
   }
 
   // it's run in single thread, and is not thread safe

--- a/client/src/main/java/org/apache/uniffle/client/impl/FailedBlockSendTracker.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/FailedBlockSendTracker.java
@@ -119,4 +119,11 @@ public class FailedBlockSendTracker {
     trackingNeedSplitPartitionStatusQueue.drainTo(trackingPartitionStatusList);
     return trackingPartitionStatusList;
   }
+
+  public boolean isEmpty() {
+    if (trackingBlockStatusMap.isEmpty() && trackingNeedSplitPartitionStatusQueue.isEmpty()) {
+      return true;
+    }
+    return false;
+  }
 }

--- a/common/src/test/java/org/apache/uniffle/common/ShuffleBlockInfoTest.java
+++ b/common/src/test/java/org/apache/uniffle/common/ShuffleBlockInfoTest.java
@@ -19,12 +19,40 @@ package org.apache.uniffle.common;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Function;
 
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ShuffleBlockInfoTest {
+
+  @Test
+  public void testStaleAssignment() throws Exception {
+    List<ShuffleServerInfo> servers =
+        Collections.singletonList(new ShuffleServerInfo("0", "localhost", 1234));
+    ShuffleBlockInfo blockInfo =
+        new ShuffleBlockInfo(1, 2, 3, 4, 5, new byte[1], servers, 9, 1, 9, null);
+    // case1: null partition assignment function, it should always be false.
+    assertFalse(blockInfo.isStaleAssignment());
+
+    // case2: stale assignment
+    Function<Integer, List<ShuffleServerInfo>> partitionAssignmentRetrieveFunc =
+        integer -> Collections.singletonList(new ShuffleServerInfo("1", "localhost", 1234));
+    blockInfo =
+        new ShuffleBlockInfo(
+            1, 2, 3, 4, 5, new byte[1], servers, 9, 1, 9, partitionAssignmentRetrieveFunc);
+    assertTrue(blockInfo.isStaleAssignment());
+
+    // case3: same assignment
+    partitionAssignmentRetrieveFunc = integer -> servers;
+    blockInfo =
+        new ShuffleBlockInfo(
+            1, 2, 3, 4, 5, new byte[1], servers, 9, 1, 9, partitionAssignmentRetrieveFunc);
+    assertFalse(blockInfo.isStaleAssignment());
+  }
 
   @Test
   public void testToString() {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fast fail for those stale assign blocks for partition reassign

### Why are the changes needed?

for #2502

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Add unit tests
