### PR TITLE
[#2520] fix(spark3): Shuffle write total duration is incorrectly accumulated in event log

### DIFF
--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/events/ShuffleWriteTimes.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/events/ShuffleWriteTimes.java
@@ -80,6 +80,5 @@ public class ShuffleWriteTimes {
     sort += times.getSort();
     requireMemory += times.getRequireMemory();
     waitFinish += times.getWaitFinish();
-    total += times.getTotal();
   }
 }

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/WriteBufferManager.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/WriteBufferManager.java
@@ -381,7 +381,7 @@ public class WriteBufferManager extends MemoryConsumer {
       partitionList.sort(
           Comparator.comparingInt(o -> buffers.get(o) == null ? 0 : buffers.get(o).getMemoryUsed())
               .reversed());
-      sortTime += start;
+      sortTime += System.currentTimeMillis() - start;
       targetSpillSize = (long) ((getUsedBytes() - getInSendListBytes()) * bufferSpillRatio);
     }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Shuffle write total duration is incorrectly accumulated in event log

### Why are the changes needed?

fix #2520

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Needn't
