### PR TITLE
[#2526] improvement: Reset the chunkID if it overflow

### DIFF
--- a/server/src/main/java/org/apache/uniffle/server/buffer/lab/ChunkCreator.java
+++ b/server/src/main/java/org/apache/uniffle/server/buffer/lab/ChunkCreator.java
@@ -131,7 +131,8 @@ public class ChunkCreator {
     int id = chunkID.getAndIncrement();
     // if chunkID overflow
     if (id <= 0) {
-      id = handleChunkIdOverflow();
+      chunkID.compareAndSet(id, chunksPool.maxCount + 1);
+      id = chunkID.getAndIncrement();
     }
     Preconditions.checkArgument(id > 0, "chunkId should be positive.");
     chunk = new OffheapChunk(size, id, pool);

--- a/server/src/main/java/org/apache/uniffle/server/buffer/lab/ChunkCreator.java
+++ b/server/src/main/java/org/apache/uniffle/server/buffer/lab/ChunkCreator.java
@@ -129,7 +129,7 @@ public class ChunkCreator {
   private Chunk createChunk(boolean pool, int size) {
     Chunk chunk;
     int id = chunkID.getAndIncrement();
-    // if chunkID overflow
+    // if chunkID overflow, reset it.
     if (id <= 0) {
       chunkID.compareAndSet(id, chunksPool.maxCount + 1);
       id = chunkID.getAndIncrement();

--- a/server/src/main/java/org/apache/uniffle/server/buffer/lab/ChunkCreator.java
+++ b/server/src/main/java/org/apache/uniffle/server/buffer/lab/ChunkCreator.java
@@ -126,6 +126,13 @@ public class ChunkCreator {
   private Chunk createChunk(boolean pool, int size) {
     Chunk chunk;
     int id = chunkID.getAndIncrement();
+    // if chunkID overflow
+    if (id <= 0) {
+      int maxChunkId = chunkIdMap.keySet().stream().mapToInt(Integer::intValue).max().orElse(0);
+      int newStartId = maxChunkId + 1;
+      chunkID.set(newStartId);
+      id = chunkID.getAndIncrement();
+    }
     Preconditions.checkArgument(id > 0, "chunkId should be positive.");
     chunk = new OffheapChunk(size, id, pool);
     this.chunkIdMap.put(chunk.getId(), chunk);

--- a/server/src/main/java/org/apache/uniffle/server/buffer/lab/ChunkCreator.java
+++ b/server/src/main/java/org/apache/uniffle/server/buffer/lab/ChunkCreator.java
@@ -51,9 +51,6 @@ public class ChunkCreator {
   private final ChunkPool chunksPool;
   private final int chunkSize;
 
-  // Lock to handle overflow
-  private final Object chunkIdOverflowLock = new Object();
-
   ChunkCreator(int chunkSize, long bufferCapacity, int maxAlloc) {
     this.chunkSize = chunkSize;
     this.maxAlloc = maxAlloc;
@@ -138,33 +135,6 @@ public class ChunkCreator {
     chunk = new OffheapChunk(size, id, pool);
     this.chunkIdMap.put(chunk.getId(), chunk);
     return chunk;
-  }
-
-  /**
-   * Handles the overflow of chunkID in a thread-safe manner
-   * only one thread resets the counter
-   * IDs remain unique and consecutive.
-   */
-  private int handleChunkIdOverflow() {
-    synchronized (chunkIdOverflowLock) {
-      // Double check
-      int id = chunkID.get();
-      if (id <= 0) {
-        int maxChunkId = chunkIdMap.keySet().stream()
-                .mapToInt(Integer::intValue)
-                .max()
-                .orElse(0);
-        int maxPoolChunkId = 0;
-        if (chunksPool != null) {
-          maxPoolChunkId = chunksPool.getMaxChunkIdInPool();
-        }
-        int newStartId = Math.max(maxChunkId, maxPoolChunkId) + 1;
-        chunkID.set(newStartId);
-        return chunkID.getAndIncrement();
-      } else {
-        return chunkID.getAndIncrement();
-      }
-    }
   }
 
   // Chunks from pool are created covered with strong references anyway
@@ -300,13 +270,6 @@ public class ChunkCreator {
 
     private int getMaxCount() {
       return this.maxCount;
-    }
-
-    public int getMaxChunkIdInPool() {
-      return reclaimedChunks.stream()
-              .mapToInt(Chunk::getId)
-              .max()
-              .orElse(0);
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
If the chunId overflow it will reset it to (max chunk id in the chunk pool + 1)

### Why are the changes needed?
Fix: #2526 Handle the possible overflow of the chunkId

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Unit test
