### PR TITLE
[#2545] feat: Align with spark executor cores on overlapping compression

### DIFF
--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/RssSparkConfig.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/RssSparkConfig.java
@@ -45,12 +45,12 @@ public class RssSparkConfig {
           .defaultValue(false)
           .withDescription("Whether to overlapping compress shuffle blocks.");
 
-  public static final ConfigOption<Integer> RSS_WRITE_OVERLAPPING_COMPRESSION_THREADS =
-      ConfigOptions.key("rss.client.write.overlappingCompressionThreads")
+  public static final ConfigOption<Integer> RSS_WRITE_OVERLAPPING_COMPRESSION_THREADS_PER_VCORE =
+      ConfigOptions.key("rss.client.write.overlappingCompressionThreadsPerVcore")
           .intType()
           .defaultValue(-1)
           .withDescription(
-              "The number of threads to overlapping compress shuffle blocks. If <= 0, this will be disabled.");
+              "Specifies the ratio between the number of overlapping compression threads and the number of Spark executor vcores. It's disabled by default.");
 
   public static final ConfigOption<Boolean> RSS_READ_REORDER_MULTI_SERVERS_ENABLED =
       ConfigOptions.key("rss.client.read.reorderMultiServersEnable")

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/OverlappingCompressionDataPusher.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/OverlappingCompressionDataPusher.java
@@ -29,7 +29,6 @@ import org.slf4j.LoggerFactory;
 
 import org.apache.uniffle.client.api.ShuffleWriteClient;
 import org.apache.uniffle.client.impl.FailedBlockSendTracker;
-import org.apache.uniffle.common.config.RssConf;
 import org.apache.uniffle.common.exception.RssException;
 import org.apache.uniffle.common.util.ThreadUtils;
 
@@ -48,7 +47,7 @@ public class OverlappingCompressionDataPusher extends DataPusher {
       Set<String> failedTaskIds,
       int threadPoolSize,
       int threadKeepAliveTime,
-      RssConf rssConf) {
+      int compressionThreads) {
     super(
         shuffleWriteClient,
         taskToSuccessBlockIds,
@@ -56,13 +55,10 @@ public class OverlappingCompressionDataPusher extends DataPusher {
         failedTaskIds,
         threadPoolSize,
         threadKeepAliveTime);
-
-    int compressionThreads =
-        rssConf.getInteger(RssSparkConfig.RSS_WRITE_OVERLAPPING_COMPRESSION_THREADS);
     if (compressionThreads <= 0) {
       throw new RssException(
           "Invalid rss configuration of "
-              + RssSparkConfig.RSS_WRITE_OVERLAPPING_COMPRESSION_THREADS.key()
+              + RssSparkConfig.RSS_WRITE_OVERLAPPING_COMPRESSION_THREADS_PER_VCORE.key()
               + ": "
               + compressionThreads);
     }

--- a/client-spark/common/src/test/java/org/apache/spark/shuffle/writer/OverlappingCompressionDataPusherTest.java
+++ b/client-spark/common/src/test/java/org/apache/spark/shuffle/writer/OverlappingCompressionDataPusherTest.java
@@ -26,7 +26,6 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 import com.google.common.collect.Maps;
-import org.apache.spark.shuffle.RssSparkConfig;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -37,6 +36,7 @@ import org.apache.uniffle.common.config.RssConf;
 import org.apache.uniffle.common.exception.RssException;
 import org.apache.uniffle.common.util.JavaUtils;
 
+import static org.apache.spark.shuffle.RssSparkConfig.RSS_WRITE_OVERLAPPING_COMPRESSION_THREADS_PER_VCORE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class OverlappingCompressionDataPusherTest {
@@ -51,6 +51,7 @@ public class OverlappingCompressionDataPusherTest {
     Set<String> failedTaskIds = new HashSet<>();
 
     RssConf rssConf = new RssConf();
+    int threads = rssConf.get(RSS_WRITE_OVERLAPPING_COMPRESSION_THREADS_PER_VCORE);
 
     // case1: Illegal thread number of compression
     Assertions.assertThrows(
@@ -63,11 +64,10 @@ public class OverlappingCompressionDataPusherTest {
               failedTaskIds,
               1,
               2,
-              rssConf);
+              threads);
         });
 
     // case2: Propagated into the underlying data pusher
-    rssConf.set(RssSparkConfig.RSS_WRITE_OVERLAPPING_COMPRESSION_THREADS, 1);
     DataPusher pusher =
         new OverlappingCompressionDataPusher(
             shuffleWriteClient,
@@ -76,7 +76,7 @@ public class OverlappingCompressionDataPusherTest {
             failedTaskIds,
             1,
             2,
-            rssConf);
+            1);
     pusher.setRssAppId("testSend");
 
     String taskId = "taskId1";


### PR DESCRIPTION
### What changes were proposed in this pull request?

Make the overlapping compression threads pool's threads number aligned with the spark executor vcores by the ratio of per vcore.

### Why are the changes needed?

Compression is a computing sensitive workload, we'd better to obey the rule of vcores allocation.

### Does this PR introduce _any_ user-facing change?
Yes. 
`rss.client.write.overlappingCompressionThreadsPerVcore = -1`

### How was this patch tested?

existing unit tests.
