### PR TITLE
[#2549] fix: Invalid remote storage configuration was propagated during application registration

### DIFF
--- a/client-spark/common/src/main/java/org/apache/uniffle/shuffle/manager/RssShuffleManagerBase.java
+++ b/client-spark/common/src/main/java/org/apache/uniffle/shuffle/manager/RssShuffleManagerBase.java
@@ -1440,7 +1440,8 @@ public abstract class RssShuffleManagerBase implements RssShuffleManagerInterfac
         "Finish register shuffleId {} with {} ms", shuffleId, (System.currentTimeMillis() - start));
   }
 
-  protected RemoteStorageInfo getRemoteStorageInfo() {
+  @VisibleForTesting
+  public RemoteStorageInfo getRemoteStorageInfo() {
     String storageType = sparkConf.get(RssSparkConfig.RSS_STORAGE_TYPE.key());
     RemoteStorageInfo defaultRemoteStorage = getDefaultRemoteStorageInfo(sparkConf);
     return ClientUtils.fetchRemoteStorage(

--- a/client-spark/common/src/main/java/org/apache/uniffle/shuffle/manager/RssShuffleManagerBase.java
+++ b/client-spark/common/src/main/java/org/apache/uniffle/shuffle/manager/RssShuffleManagerBase.java
@@ -1442,8 +1442,7 @@ public abstract class RssShuffleManagerBase implements RssShuffleManagerInterfac
 
   protected RemoteStorageInfo getRemoteStorageInfo() {
     String storageType = sparkConf.get(RssSparkConfig.RSS_STORAGE_TYPE.key());
-    RemoteStorageInfo defaultRemoteStorage =
-        new RemoteStorageInfo(sparkConf.get(RssSparkConfig.RSS_REMOTE_STORAGE_PATH.key(), ""));
+    RemoteStorageInfo defaultRemoteStorage = getDefaultRemoteStorageInfo(sparkConf);
     return ClientUtils.fetchRemoteStorage(
         appId, defaultRemoteStorage, dynamicConfEnabled, storageType, shuffleWriteClient);
   }

--- a/client-spark/spark3/src/test/java/org/apache/spark/shuffle/RssShuffleManagerTest.java
+++ b/client-spark/spark3/src/test/java/org/apache/spark/shuffle/RssShuffleManagerTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import org.apache.uniffle.client.util.RssClientConfig;
+import org.apache.uniffle.common.RemoteStorageInfo;
 import org.apache.uniffle.common.ShuffleDataDistributionType;
 import org.apache.uniffle.common.config.ConfigOption;
 import org.apache.uniffle.common.config.RssClientConf;
@@ -94,6 +95,26 @@ public class RssShuffleManagerTest extends RssShuffleManagerTestBase {
           RssClientConf.DATA_DISTRIBUTION_TYPE.defaultValue(),
           RssShuffleManager.getDataDistributionType(sparkConf));
     }
+  }
+
+  @Test
+  public void testGetRemoteStorageInfo() {
+    setupMockedRssShuffleUtils(StatusCode.SUCCESS);
+
+    SparkConf conf = new SparkConf();
+    conf.set(RssSparkConfig.RSS_DYNAMIC_CLIENT_CONF_ENABLED.key(), "false");
+    conf.set(RssSparkConfig.RSS_COORDINATOR_QUORUM.key(), "m1:8001,m2:8002");
+    conf.set("spark.driver.host", "localhost");
+    conf.set("spark.rss.storage.type", StorageType.LOCALFILE.name());
+    conf.set(RssSparkConfig.RSS_TEST_MODE_ENABLE, true);
+
+    // inject some hadoop configs
+    conf.set("spark.rss.hadoop.k1", "v1");
+    conf.set("spark.rss.hadoop.k2", "v2");
+
+    RssShuffleManager shuffleManager = new RssShuffleManager(conf, true);
+    RemoteStorageInfo remoteStorageInfo = shuffleManager.getRemoteStorageInfo();
+    assertEquals(2, remoteStorageInfo.getConfItems().size());
   }
 
   @Test


### PR DESCRIPTION
### What changes were proposed in this pull request?

fix invalid remote storage configuration was propagated during application registration

### Why are the changes needed?

fix #2549

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?
Yes. existing tests and internal cluster tests.
