### PR TITLE
[#2560] improvement(client): Fast fail on hadoop reader initialization failure

### DIFF
--- a/client-spark/common/src/test/java/org/apache/spark/shuffle/reader/RssShuffleDataIteratorTest.java
+++ b/client-spark/common/src/test/java/org/apache/spark/shuffle/reader/RssShuffleDataIteratorTest.java
@@ -229,7 +229,8 @@ public class RssShuffleDataIteratorTest extends AbstractRssReaderTest {
       }
       fail(EXPECTED_EXCEPTION_MESSAGE);
     } catch (Exception e) {
-      assertTrue(e.getMessage().startsWith("Blocks read inconsistent: expected"));
+      // the underlying hdfs files have been deleted, so that the reader will initialize failed
+      assertTrue(e.getMessage().contains("don't exist or is not a file"));
     }
   }
 

--- a/client/src/test/java/org/apache/uniffle/client/impl/ShuffleReadClientImplTest.java
+++ b/client/src/test/java/org/apache/uniffle/client/impl/ShuffleReadClientImplTest.java
@@ -230,7 +230,13 @@ public class ShuffleReadClientImplTest extends HadoopTestBase {
     // data file is deleted after readClient checkExpectedBlockIds
     fs.delete(dataFile, true);
 
-    assertNull(readClient.readShuffleBlockData());
+    try {
+      readClient.readShuffleBlockData();
+      fail("Hdfs file reader should fail due to non-existence");
+    } catch (Exception e) {
+      // ignore
+    }
+
     try {
       fs.listStatus(dataFile);
       fail("Index file should be deleted");

--- a/storage/src/main/java/org/apache/uniffle/storage/handler/impl/HadoopClientReadHandler.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/handler/impl/HadoopClientReadHandler.java
@@ -190,6 +190,7 @@ public class HadoopClientReadHandler extends AbstractClientReadHandler {
           readHandlers.add(handler);
         } catch (Exception e) {
           LOG.warn("Can't create ShuffleReaderHandler for " + filePrefix, e);
+          throw new RssException(e);
         }
       }
       Collections.shuffle(readHandlers);


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fast fail on hadoop reader initialization failure

### Why are the changes needed?

When the hadoop reader initialization failed, this exception will be ignored. When the final unexcepted blockIds throws, it’s hard to find out the root cause.

And so, we should fast fail in this case.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing unit tests.