### PR TITLE
[#2539] fix(client-spark): NPE in DataPusher when sendShuffleData fails

### DIFF
--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/DataPusher.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/DataPusher.java
@@ -113,7 +113,7 @@ public class DataPusher implements Closeable {
                     taskToFailedBlockSendTracker, taskId, result.getFailedBlockSendTracker());
               } finally {
                 WriteBufferManager bufferManager = event.getBufferManager();
-                if (bufferManager != null) {
+                if (bufferManager != null && result != null) {
                   ShuffleServerPushCostTracker shuffleServerPushCostTracker =
                       result.getShuffleServerPushCostTracker();
                   bufferManager.merge(shuffleServerPushCostTracker);


### PR DESCRIPTION
### What changes were proposed in this pull request?

`NullPointerException` occurs in `DataPusher` when `sendShuffleData()` throws an exception, leaving `result` null, but the finally block attempts to access `result.getShuffleServerPushCostTracker()` without null checking.

### Why are the changes needed?

Add null check to `result` before accessing shuffle server push cost tracker.
Fix: #2539 

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?

`DataPusherTest` passes.