### PR TITLE
[MINOR] improvement(client): Shorten log for multi replica client reader

### DIFF
--- a/storage/src/main/java/org/apache/uniffle/storage/handler/impl/MultiReplicaClientReadHandler.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/handler/impl/MultiReplicaClientReadHandler.java
@@ -80,12 +80,12 @@ public class MultiReplicaClientReadHandler extends AbstractClientReadHandler {
           // If this is not the last server, then read next.
           if (readHandlerIndex < handlers.size() - 1) {
             LOG.info(
-                "Finished read from {}/{} [{}], haven't finished read all the blocks. Will read from next server {}",
+                "Finished read from {}/{} [{}], haven't finished read all the blocks. Will read from next server {}. message: {}",
                 readHandlerIndex + 1,
                 handlers.size(),
                 shuffleServerInfos.get(readHandlerIndex).getId(),
                 shuffleServerInfos.get(readHandlerIndex + 1).getId(),
-                e);
+                e.getMessage());
           } else {
             LOG.warn(
                 "Finished read from {}/{} [{}], but haven't finished read all the blocks.",


### PR DESCRIPTION
### What changes were proposed in this pull request?

When multi replica or partition split is enabled,  the log with blockId unexception message will always show when reading from one shuffle-server, that will make someone confuse. 

### Why are the changes needed?

Shorten log for multi replica client reader

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Neen't
