### PR TITLE
[#2563] improvement(spark): Add more logs of shuffle write on reassignment failure

### DIFF
--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/TaskAttemptAssignment.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/TaskAttemptAssignment.java
@@ -17,6 +17,7 @@
 
 package org.apache.spark.shuffle.writer;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -65,5 +66,17 @@ public class TaskAttemptAssignment {
     // for those load balance partition split, once split, skip the following split.
     PartitionSplitInfo splitInfo = this.handle.getPartitionSplitInfo(partitionId);
     return splitInfo.isSplit() && splitInfo.getMode() == PartitionSplitMode.LOAD_BALANCE;
+  }
+
+  /**
+   * @param partitionId
+   * @return all assigned shuffle servers for one partition id
+   */
+  public List<ShuffleServerInfo> list(int partitionId) {
+    Map<Integer, List<ShuffleServerInfo>> servers = this.handle.getAllPartitionServersForReader();
+    if (servers == null) {
+      return Collections.emptyList();
+    }
+    return servers.get(partitionId);
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is to add more logs of shuffle write on reassignment failure for the next inspection when it occurs.

### Why are the changes needed?

for #2563 .

```
25/07/29 08:13:25 ERROR TaskResources: Task 14257 failed by error: 
org.apache.uniffle.common.exception.RssException: No available replacement server for: 10.xxxxx-23100-23104
	at org.apache.spark.shuffle.writer.RssShuffleWriter.reassignAndResendBlocks(RssShuffleWriter.java:832)
	at org.apache.spark.shuffle.writer.RssShuffleWriter.collectFailedBlocksToResend(RssShuffleWriter.java:672)
	at org.apache.spark.shuffle.writer.RssShuffleWriter.checkDataIfAnyFailure(RssShuffleWriter.java:570)
	at org.apache.spark.shuffle.writer.RssShuffleWriter.checkBlockSendResult(RssShuffleWriter.java:532)
	at org.apache.spark.shuffle.writer.RssShuffleWriter.internalCheckBlockSendResult(RssShuffleWriter.java:518)
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Neen't
