### PR TITLE
[#2525][FOLLOWUP] remove metric `buffer_block_size`

### DIFF
--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServerMetrics.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServerMetrics.java
@@ -155,7 +155,6 @@ public class ShuffleServerMetrics {
   private static final String LAB_CHUNK_POOL_REMAIN_PERCENT = "lab_chunk_pool_remain_percent";
   private static final String NOT_ON_LAB_BLOCK_COUNT = "not_on_lab_block_count";
   private static final String ON_LAB_BLOCK_COUNT = "on_lab_block_count";
-  private static final String BUFFER_BLOCK_SIZE = "buffer_block_size";
   public static final String TOPN_OF_TOTAL_DATA_SIZE_FOR_APP = "topN_of_total_data_size_for_app";
   public static final String TOPN_OF_IN_MEMORY_DATA_SIZE_FOR_APP =
       "topN_of_in_memory_data_size_for_app";
@@ -280,7 +279,6 @@ public class ShuffleServerMetrics {
   public static Gauge gaugeLABChunkPoolRemainPercent;
   public static Counter counterBlockNotOnLAB;
   public static Counter counterBlockOnLAB;
-  public static Summary summaryBufferBlockSize;
 
   private static MetricsManager metricsManager;
   private static boolean isRegister = false;
@@ -524,7 +522,6 @@ public class ShuffleServerMetrics {
 
     counterBlockNotOnLAB = metricsManager.addCounter(NOT_ON_LAB_BLOCK_COUNT);
     counterBlockOnLAB = metricsManager.addCounter(ON_LAB_BLOCK_COUNT);
-    summaryBufferBlockSize = metricsManager.addSummary(BUFFER_BLOCK_SIZE);
     gaugeTotalDataSizeUsage =
         Gauge.build()
             .name(TOPN_OF_TOTAL_DATA_SIZE_FOR_APP)

--- a/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferWithLinkedList.java
+++ b/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferWithLinkedList.java
@@ -37,7 +37,6 @@ import org.apache.uniffle.common.util.Constants;
 import org.apache.uniffle.common.util.JavaUtils;
 import org.apache.uniffle.server.ShuffleDataFlushEvent;
 import org.apache.uniffle.server.ShuffleFlushManager;
-import org.apache.uniffle.server.ShuffleServerMetrics;
 
 public class ShuffleBufferWithLinkedList extends AbstractShuffleBuffer {
   // blocks will be added to inFlushBlockMap as <eventId, blocks> pair
@@ -60,7 +59,6 @@ public class ShuffleBufferWithLinkedList extends AbstractShuffleBuffer {
     long currentDataLength = 0;
 
     for (ShufflePartitionedBlock block : data.getBlockList()) {
-      ShuffleServerMetrics.summaryBufferBlockSize.observe(block.getDataLength());
       // If sendShuffleData retried, we may receive duplicate block. The duplicate
       // block would gc without release. Here we must release the duplicated block.
       if (addBlock(block)) {

--- a/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferWithSkipList.java
+++ b/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferWithSkipList.java
@@ -39,7 +39,6 @@ import org.apache.uniffle.common.util.Constants;
 import org.apache.uniffle.common.util.JavaUtils;
 import org.apache.uniffle.server.ShuffleDataFlushEvent;
 import org.apache.uniffle.server.ShuffleFlushManager;
-import org.apache.uniffle.server.ShuffleServerMetrics;
 
 public class ShuffleBufferWithSkipList extends AbstractShuffleBuffer {
   private ConcurrentSkipListMap<Long, ShufflePartitionedBlock> blocksMap;
@@ -67,7 +66,6 @@ public class ShuffleBufferWithSkipList extends AbstractShuffleBuffer {
     long currentDataLength = 0;
 
     for (ShufflePartitionedBlock block : data.getBlockList()) {
-      ShuffleServerMetrics.summaryBufferBlockSize.observe(block.getDataLength());
       // If sendShuffleData retried, we may receive duplicate block. The duplicate
       // block would gc without release. Here we must release the duplicated block.
       if (!blocksMap.containsKey(block.getBlockId())) {


### PR DESCRIPTION

<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#123] feat(server,coordinator): support xxx"
     - "[#123] feat(common): support xxx"
     - "[MINOR] improvement(script): fix style"
     - "[MINOR] improvement(ci): add some examples and notice"
     - "[#233] fix: check null before access result in xxx"
     - "[#233][FOLLOWUP] improvement(dashboard): display something xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?
<!--
(Please outline the changes and how this PR fixes the issue.)
-->
Remove metric `buffer_block_size`

### Why are the changes needed?
<!--
(Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, describe the bug.)

Fix: # (issue)
-->
The observations of `Summary` are expensive due to the streaming quantile calculation and `synchronized` is used in `Summary.observe`.

```shell
"epollEventLoopGroup-3-130" #341 prio=10 os_prio=0 cpu=51979.29ms elapsed=2103.78s tid=0x000004c0882e7000 nid=0x486d waiting for monitor entry  [0x00007f21769e7000]
   java.lang.Thread.State: BLOCKED (on object monitor)
        at io.prometheus.client.TimeWindowQuantiles.insert(TimeWindowQuantiles.java:36)
        - waiting to lock <0x00000003006a7df8> (a io.prometheus.client.TimeWindowQuantiles)
        at io.prometheus.client.Summary$Child.observe(Summary.java:283)
        at io.prometheus.client.Summary.observe(Summary.java:309)
        at org.apache.uniffle.server.buffer.SkipListShuffleBuffer.append(SkipListShuffleBuffer.java:62)
```

### Does this PR introduce _any_ user-facing change?
<!--
(Please list the user-facing changes introduced by your change, including
  1. Change in user-facing APIs.
  2. Addition or removal of property keys.)
-->
No.

### How was this patch tested?
<!--
(Please test your changes, and provide instructions on how to test it:
  1. If you add a feature or fix a bug, add a test to cover your changes. 
  2. If you fix a flaky test, repeat it for many times to prove it works.)
-->
CI
