### PR TITLE
[#2576] fix: Warm up java version var to eliminate lock on creating concurrent hashmap

### DIFF
--- a/common/src/main/java/org/apache/uniffle/common/util/JavaUtils.java
+++ b/common/src/main/java/org/apache/uniffle/common/util/JavaUtils.java
@@ -33,9 +33,12 @@ public class JavaUtils {
   private static final Logger logger = LoggerFactory.getLogger(JavaUtils.class);
   private static final String JAVA_9 = "JAVA_9";
 
+  private static final boolean JAVA9_PLUS =
+      Enums.getIfPresent(JavaVersion.class, JAVA_9).isPresent()
+          && SystemUtils.isJavaVersionAtLeast(JavaVersion.JAVA_9);
+
   public static boolean isJavaVersionAtLeastJava9() {
-    return Enums.getIfPresent(JavaVersion.class, JAVA_9).isPresent()
-        && SystemUtils.isJavaVersionAtLeast(JavaVersion.JAVA_9);
+    return JAVA9_PLUS;
   }
 
   /** Closes the given object, ignoring IOExceptions. */


### PR DESCRIPTION
### What changes were proposed in this pull request?

Cache the java9+ var to eliminate lock when creating concurrent hashmap

### Why are the changes needed?

fix #2576 .

`Enums.getIfPresent` will always using the global lock, this is unnecessary and hurt the performance

### Does this PR introduce _any_ user-facing change?
<!--
(Please list the user-facing changes introduced by your change, including
  1. Change in user-facing APIs.
  2. Addition or removal of property keys.)
-->
No.

### How was this patch tested?

Existing tests.
