### PR TITLE
[#2568] feat(spark): Use space-efficient protobuf for `MutableShuffleHandleInfo` to reduce RPC memory overhead

### DIFF
--- a/client-spark/common/src/test/java/org/apache/spark/shuffle/handle/MutableShuffleHandleInfoTest.java
+++ b/client-spark/common/src/test/java/org/apache/spark/shuffle/handle/MutableShuffleHandleInfoTest.java
@@ -61,8 +61,11 @@ public class MutableShuffleHandleInfoTest {
       if (list2 == null || list1.size() != list2.size()) {
         return false;
       }
-      if (!new HashSet<>(list1).equals(new HashSet<>(list2))) {
-        return false;
+      // all the elements should be equal with the same index
+      for (int i = 0; i < list1.size(); i++) {
+        if (!list2.get(i).equals(list1.get(i))) {
+          return false;
+        }
       }
     }
     return true;

--- a/common/src/main/java/org/apache/uniffle/common/ShuffleServerInfo.java
+++ b/common/src/main/java/org/apache/uniffle/common/ShuffleServerInfo.java
@@ -114,7 +114,7 @@ public class ShuffleServerInfo implements Serializable {
     }
   }
 
-  private static ShuffleServerInfo convertFromShuffleServerId(
+  public static ShuffleServerInfo convertFromShuffleServerId(
       RssProtos.ShuffleServerId shuffleServerId) {
     ShuffleServerInfo shuffleServerInfo =
         new ShuffleServerInfo(

--- a/proto/src/main/proto/Rss.proto
+++ b/proto/src/main/proto/Rss.proto
@@ -685,12 +685,23 @@ message StageAttemptShuffleHandleInfo {
 
 message MutableShuffleHandleInfo {
   int32 shuffleId = 1;
-  map<int32, PartitionReplicaServers> partitionToServers = 2;
+  repeated ServerToPartitionsItem serverToPartitionItem = 2;
   RemoteStorageInfo remoteStorageInfo = 3;
 
   map<string, ReplacementServers> excludedServerToReplacements = 4;
   repeated int32 splitPartitionId = 5;
   PartitionSplitMode partitionSplitMode = 6;
+
+}
+
+message ServerToPartitionsItem {
+  ShuffleServerId serverId = 1;
+  repeated PartitionReplicaItem partitionToReplicaItems = 2;
+}
+
+message PartitionReplicaItem {
+  int32 partitionId = 1;
+  int32 replicaIndex = 2;
 }
 
 enum PartitionSplitMode {

--- a/proto/src/main/proto/Rss.proto
+++ b/proto/src/main/proto/Rss.proto
@@ -702,6 +702,8 @@ message ServerToPartitionsItem {
 message PartitionReplicaItem {
   int32 partitionId = 1;
   int32 replicaIndex = 2;
+  // the index of assigned servers list
+  int32 sequenceIndex = 3;
 }
 
 enum PartitionSplitMode {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR uses a space-efficient protobuf data structure to store the partitions-to-servers mapping, thereby reducing the RPC cost.

### Why are the changes needed?

This is the part of PR for the #2568. 

In large-scale Spark jobs, the number of partitions can reach up to 20K, whereas the number of assigned shuffle servers remains smaller than the total number of nodes in the Uniffle cluster.
Prior to this PR, both the driver and the client (when reassignment was enabled) required substantial memory for RPC transfers, which could significantly increase the frequency of driver garbage collection.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Unit tests.
