### PR TITLE
[#2581] fix(spark): Use `SparkContext getActive` instead of `getOrCreate` to align with method semantics

### DIFF
--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/RssSparkShuffleUtils.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/RssSparkShuffleUtils.java
@@ -262,13 +262,10 @@ public class RssSparkShuffleUtils {
    * Get current active {@link SparkContext}. It should be called inside Driver since we don't mean
    * to create any new {@link SparkContext} here.
    *
-   * <p>Note: We could use "SparkContext.getActive()" instead of "SparkContext.getOrCreate()" if the
-   * "getActive" method is not declared as package private in Scala.
-   *
    * @return Active SparkContext created by Driver.
    */
   public static SparkContext getActiveSparkContext() {
-    return SparkContext.getOrCreate();
+    return SparkContext.getActive().get();
   }
 
   /**

--- a/client-spark/common/src/test/java/org/apache/spark/shuffle/RssSparkShuffleUtilsTest.java
+++ b/client-spark/common/src/test/java/org/apache/spark/shuffle/RssSparkShuffleUtilsTest.java
@@ -24,40 +24,20 @@ import java.util.Set;
 import com.google.common.collect.Maps;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.spark.SparkConf;
-import org.apache.spark.SparkContext;
 import org.junit.jupiter.api.Test;
 
 import org.apache.uniffle.client.util.RssClientConfig;
-import org.apache.uniffle.common.exception.RssException;
 import org.apache.uniffle.common.util.Constants;
 import org.apache.uniffle.storage.util.StorageType;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class RssSparkShuffleUtilsTest {
 
   private static final String EXPECTED_EXCEPTION_MESSAGE = "Exception should be thrown";
-
-  @Test
-  public void testGetActiveSparkContext() {
-    assertThrows(RssException.class, RssSparkShuffleUtils::getActiveSparkContext);
-    SparkConf conf = new SparkConf();
-    conf.setMaster("local[1]");
-    conf.setAppName("test");
-    SparkContext sc = null;
-    try {
-      sc = SparkContext.getOrCreate(conf);
-      assertEquals(sc, RssSparkShuffleUtils.getActiveSparkContext());
-    } finally {
-      if (sc != null) {
-        sc.stop();
-      }
-    }
-  }
 
   @Test
   public void testAssignmentTags() {

--- a/client-spark/common/src/test/java/org/apache/spark/shuffle/RssSparkShuffleUtilsTest.java
+++ b/client-spark/common/src/test/java/org/apache/spark/shuffle/RssSparkShuffleUtilsTest.java
@@ -32,7 +32,11 @@ import org.apache.uniffle.common.exception.RssException;
 import org.apache.uniffle.common.util.Constants;
 import org.apache.uniffle.storage.util.StorageType;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class RssSparkShuffleUtilsTest {
 

--- a/client-spark/common/src/test/java/org/apache/spark/shuffle/RssSparkShuffleUtilsTest.java
+++ b/client-spark/common/src/test/java/org/apache/spark/shuffle/RssSparkShuffleUtilsTest.java
@@ -25,10 +25,10 @@ import com.google.common.collect.Maps;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.spark.SparkConf;
 import org.apache.spark.SparkContext;
-import org.apache.uniffle.common.exception.RssException;
 import org.junit.jupiter.api.Test;
 
 import org.apache.uniffle.client.util.RssClientConfig;
+import org.apache.uniffle.common.exception.RssException;
 import org.apache.uniffle.common.util.Constants;
 import org.apache.uniffle.storage.util.StorageType;
 
@@ -49,9 +49,9 @@ public class RssSparkShuffleUtilsTest {
       sc = SparkContext.getOrCreate(conf);
       assertEquals(sc, RssSparkShuffleUtils.getActiveSparkContext());
     } finally {
-        if (sc != null) {
-          sc.stop();
-        }
+      if (sc != null) {
+        sc.stop();
+      }
     }
   }
 

--- a/client-spark/common/src/test/java/org/apache/spark/shuffle/RssSparkShuffleUtilsTest.java
+++ b/client-spark/common/src/test/java/org/apache/spark/shuffle/RssSparkShuffleUtilsTest.java
@@ -24,20 +24,36 @@ import java.util.Set;
 import com.google.common.collect.Maps;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.spark.SparkConf;
+import org.apache.spark.SparkContext;
+import org.apache.uniffle.common.exception.RssException;
 import org.junit.jupiter.api.Test;
 
 import org.apache.uniffle.client.util.RssClientConfig;
 import org.apache.uniffle.common.util.Constants;
 import org.apache.uniffle.storage.util.StorageType;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class RssSparkShuffleUtilsTest {
 
   private static final String EXPECTED_EXCEPTION_MESSAGE = "Exception should be thrown";
+
+  @Test
+  public void testGetActiveSparkContext() {
+    assertThrows(RssException.class, RssSparkShuffleUtils::getActiveSparkContext);
+    SparkConf conf = new SparkConf();
+    conf.setMaster("local[1]");
+    conf.setAppName("test");
+    SparkContext sc = null;
+    try {
+      sc = SparkContext.getOrCreate(conf);
+      assertEquals(sc, RssSparkShuffleUtils.getActiveSparkContext());
+    } finally {
+        if (sc != null) {
+          sc.stop();
+        }
+    }
+  }
 
   @Test
   public void testAssignmentTags() {

--- a/client-spark/spark2/src/test/java/org/apache/spark/shuffle/RssSpark2ShuffleUtilsTest.java
+++ b/client-spark/spark2/src/test/java/org/apache/spark/shuffle/RssSpark2ShuffleUtilsTest.java
@@ -17,13 +17,36 @@
 
 package org.apache.spark.shuffle;
 
+import org.apache.spark.SparkConf;
+import org.apache.spark.SparkContext;
 import org.junit.jupiter.api.Test;
 
+import org.apache.uniffle.common.exception.RssException;
 import org.apache.uniffle.common.exception.RssFetchFailedException;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class RssSpark2ShuffleUtilsTest {
+
+  @Test
+  public void testGetActiveSparkContext() {
+    assertThrows(RssException.class, RssSparkShuffleUtils::getActiveSparkContext);
+    SparkConf conf = new SparkConf();
+    conf.setMaster("local[1]");
+    conf.setAppName("test");
+    SparkContext sc = null;
+    try {
+      sc = SparkContext.getOrCreate(conf);
+      assertEquals(sc, RssSparkShuffleUtils.getActiveSparkContext());
+    } finally {
+      if (sc != null) {
+        sc.stop();
+      }
+    }
+  }
+
   @Test
   public void testCreateFetchFailedException() {
     FetchFailedException ffe = RssSparkShuffleUtils.createFetchFailedException(0, -1, 10, null);

--- a/client-spark/spark3/src/test/java/org/apache/spark/shuffle/RssSpark3ShuffleUtilsTest.java
+++ b/client-spark/spark3/src/test/java/org/apache/spark/shuffle/RssSpark3ShuffleUtilsTest.java
@@ -17,13 +17,36 @@
 
 package org.apache.spark.shuffle;
 
+import org.apache.spark.SparkConf;
+import org.apache.spark.SparkContext;
 import org.junit.jupiter.api.Test;
 
+import org.apache.uniffle.common.exception.RssException;
 import org.apache.uniffle.common.exception.RssFetchFailedException;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class RssSpark3ShuffleUtilsTest {
+
+  @Test
+  public void testGetActiveSparkContext() {
+    assertThrows(RssException.class, RssSparkShuffleUtils::getActiveSparkContext);
+    SparkConf conf = new SparkConf();
+    conf.setMaster("local[1]");
+    conf.setAppName("test");
+    SparkContext sc = null;
+    try {
+      sc = SparkContext.getOrCreate(conf);
+      assertEquals(sc, RssSparkShuffleUtils.getActiveSparkContext());
+    } finally {
+      if (sc != null) {
+        sc.stop();
+      }
+    }
+  }
+
   @Test
   public void testCreateFetchFailedException() {
     FetchFailedException ffe = RssSparkShuffleUtils.createFetchFailedException(0, -1, 10, null);


### PR DESCRIPTION
### What changes were proposed in this pull request?

Use `SparkContext.getActive` instead of `getOrCreate` to better align with the intended semantics for external invocation.

### Why are the changes needed?

Fix #2581

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Added unit test