### PR TITLE
[#2586] fix(spark): Support writer switching servers on partition split with LOAD_BALANCE mode without reassign

### DIFF
--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/handle/ShuffleHandleInfo.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/handle/ShuffleHandleInfo.java
@@ -17,6 +17,7 @@
 
 package org.apache.spark.shuffle.handle;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -36,7 +37,12 @@ public interface ShuffleHandleInfo {
    * shuffleServers. Implementations might return dynamic, up-to-date information here. Returns
    * partitionId -> [replica1, replica2, ...]
    */
-  Map<Integer, List<ShuffleServerInfo>> getAvailablePartitionServersForWriter();
+  default Map<Integer, List<ShuffleServerInfo>> getAvailablePartitionServersForWriter() {
+    return getAvailablePartitionServersForWriter(Collections.emptyMap());
+  }
+
+  Map<Integer, List<ShuffleServerInfo>> getAvailablePartitionServersForWriter(
+      Map<Integer, List<ShuffleServerInfo>> exclusivePartitionServers);
 
   /**
    * Get all servers ever assigned to writers group by partitionId for reader to get the data

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/handle/SimpleShuffleHandleInfo.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/handle/SimpleShuffleHandleInfo.java
@@ -28,6 +28,7 @@ import org.apache.spark.shuffle.handle.split.PartitionSplitInfo;
 import org.apache.uniffle.client.PartitionDataReplicaRequirementTracking;
 import org.apache.uniffle.common.RemoteStorageInfo;
 import org.apache.uniffle.common.ShuffleServerInfo;
+import org.apache.uniffle.common.exception.RssException;
 
 /**
  * Class for holding, 1. partition ID -> shuffle servers mapping. 2. remote storage info
@@ -54,7 +55,12 @@ public class SimpleShuffleHandleInfo extends ShuffleHandleInfoBase implements Se
   }
 
   @Override
-  public Map<Integer, List<ShuffleServerInfo>> getAvailablePartitionServersForWriter() {
+  public Map<Integer, List<ShuffleServerInfo>> getAvailablePartitionServersForWriter(
+      Map<Integer, List<ShuffleServerInfo>> exclusiveServers) {
+    if (exclusiveServers != null && !exclusiveServers.isEmpty()) {
+      throw new RssException(
+          "Exclusive servers are not supported when getting available partition servers for shuffle writer");
+    }
     return partitionToServers;
   }
 

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/handle/StageAttemptShuffleHandleInfo.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/handle/StageAttemptShuffleHandleInfo.java
@@ -63,8 +63,9 @@ public class StageAttemptShuffleHandleInfo extends ShuffleHandleInfoBase {
   }
 
   @Override
-  public Map<Integer, List<ShuffleServerInfo>> getAvailablePartitionServersForWriter() {
-    return current.getAvailablePartitionServersForWriter();
+  public Map<Integer, List<ShuffleServerInfo>> getAvailablePartitionServersForWriter(
+      Map<Integer, List<ShuffleServerInfo>> exclusiveServers) {
+    return current.getAvailablePartitionServersForWriter(exclusiveServers);
   }
 
   @Override

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/TaskAttemptAssignment.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/TaskAttemptAssignment.java
@@ -17,9 +17,13 @@
 
 package org.apache.spark.shuffle.writer;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.stream.Collectors;
 
 import org.apache.spark.shuffle.handle.ShuffleHandleInfo;
 import org.apache.spark.shuffle.handle.split.PartitionSplitInfo;
@@ -29,6 +33,7 @@ import org.slf4j.LoggerFactory;
 import org.apache.uniffle.common.PartitionSplitMode;
 import org.apache.uniffle.common.ShuffleServerInfo;
 import org.apache.uniffle.common.exception.RssException;
+import org.apache.uniffle.common.util.JavaUtils;
 
 /** This class is to get the partition assignment for ShuffleWriter. */
 public class TaskAttemptAssignment {
@@ -38,10 +43,15 @@ public class TaskAttemptAssignment {
   private ShuffleHandleInfo handle;
   private final long taskAttemptId;
 
+  // key: partitionId, values: exclusive servers.
+  // this is for the partition split mechanism of load balance mode
+  private final Map<Integer, Set<ShuffleServerInfo>> exclusiveServersForPartition;
+
   public TaskAttemptAssignment(long taskAttemptId, ShuffleHandleInfo shuffleHandleInfo) {
     this.update(shuffleHandleInfo);
     this.handle = shuffleHandleInfo;
     this.taskAttemptId = taskAttemptId;
+    this.exclusiveServersForPartition = JavaUtils.newConcurrentMap();
   }
 
   /**
@@ -58,14 +68,36 @@ public class TaskAttemptAssignment {
     if (handle == null) {
       throw new RssException("Errors on updating shuffle handle by the empty handleInfo.");
     }
-    this.assignment = handle.getAvailablePartitionServersForWriter();
+    this.assignment =
+        handle.getAvailablePartitionServersForWriter(
+            this.exclusiveServersForPartition.entrySet().stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, x -> new ArrayList<>(x.getValue()))));
     this.handle = handle;
   }
 
-  public boolean isSkipPartitionSplit(int partitionId) {
-    // for those load balance partition split, once split, skip the following split.
+  private boolean hasBeenLoadBalanced(int partitionId) {
     PartitionSplitInfo splitInfo = this.handle.getPartitionSplitInfo(partitionId);
     return splitInfo.isSplit() && splitInfo.getMode() == PartitionSplitMode.LOAD_BALANCE;
+  }
+
+  /**
+   * If partition has been load balanced and marked as split, it could update assignment by the next
+   * servers. Otherwise, it will directly return false that will trigger reassignment.
+   *
+   * @param partitionId
+   * @param exclusiveServers
+   * @return
+   */
+  public boolean updatePartitionAssignment(
+      int partitionId, List<ShuffleServerInfo> exclusiveServers) {
+    if (hasBeenLoadBalanced(partitionId)) {
+      Set<ShuffleServerInfo> servers =
+          this.exclusiveServersForPartition.computeIfAbsent(
+              partitionId, k -> new ConcurrentSkipListSet<>());
+      servers.addAll(exclusiveServers);
+      return true;
+    }
+    return false;
   }
 
   /**

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
@@ -704,9 +704,13 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
     for (Map.Entry<Integer, List<ReceivingFailureServer>> entry :
         failurePartitionToServers.entrySet()) {
       int partitionId = entry.getKey();
-      boolean isSkip = taskAttemptAssignment.isSkipPartitionSplit(partitionId);
-      if (!isSkip) {
-        partitionToServersReassignList.put(partitionId, entry.getValue());
+      List<ReceivingFailureServer> failureServers = entry.getValue();
+      if (!taskAttemptAssignment.updatePartitionAssignment(
+          partitionId,
+          failureServers.stream()
+              .map(x -> ShuffleServerInfo.from(x.getServerId()))
+              .collect(Collectors.toList()))) {
+        partitionToServersReassignList.put(partitionId, failureServers);
       }
     }
 

--- a/common/src/test/java/org/apache/uniffle/common/ShuffleServerInfoTest.java
+++ b/common/src/test/java/org/apache/uniffle/common/ShuffleServerInfoTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class ShuffleServerInfoTest {
 
@@ -59,5 +60,22 @@ public class ShuffleServerInfoTest {
             + newInfo.getNettyPort()
             + "]}",
         newInfo.toString());
+  }
+
+  @Test
+  public void testFromServerId() {
+    // case1
+    ShuffleServerInfo info = new ShuffleServerInfo("localhost", 1234);
+    String serverId = info.getId();
+    assertEquals(info, ShuffleServerInfo.from(serverId));
+
+    // case2
+    info = new ShuffleServerInfo("localhost", 1234, 5678);
+    serverId = info.getId();
+    assertEquals(info, ShuffleServerInfo.from(serverId));
+
+    // case3: illegal server id
+    String illegalServerId = "illegal";
+    assertNull(ShuffleServerInfo.from(illegalServerId));
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is to support writer switching servers on partition split with LOAD_BALANCE mode without reassign. 

### Why are the changes needed?

fix #2586 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Unit tests
