### PR TITLE
[#2494] feat(spark): Enable overlapping compression by default

### DIFF
--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/RssSparkConfig.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/RssSparkConfig.java
@@ -42,7 +42,7 @@ public class RssSparkConfig {
   public static final ConfigOption<Boolean> RSS_WRITE_OVERLAPPING_COMPRESSION_ENABLED =
       ConfigOptions.key("rss.client.write.overlappingCompressionEnable")
           .booleanType()
-          .defaultValue(false)
+          .defaultValue(true)
           .withDescription("Whether to overlapping compress shuffle blocks.");
 
   public static final ConfigOption<Integer> RSS_WRITE_OVERLAPPING_COMPRESSION_THREADS_PER_VCORE =

--- a/client-spark/common/src/test/java/org/apache/spark/shuffle/writer/WriteBufferManagerTest.java
+++ b/client-spark/common/src/test/java/org/apache/spark/shuffle/writer/WriteBufferManagerTest.java
@@ -120,6 +120,10 @@ public class WriteBufferManagerTest {
     conf.set(
         RssSparkConfig.SPARK_RSS_CONFIG_PREFIX + RssClientConf.BLOCKID_TASK_ATTEMPT_ID_BITS.key(),
         String.valueOf(layout.taskAttemptIdBits));
+    conf.set(
+        RssSparkConfig.SPARK_RSS_CONFIG_PREFIX
+            + RssSparkConfig.RSS_WRITE_OVERLAPPING_COMPRESSION_ENABLED.key(),
+        "false");
     if (!compress) {
       conf.set(RssSparkConfig.SPARK_SHUFFLE_COMPRESS_KEY, String.valueOf(false));
     }

--- a/docs/client_guide/spark_client_guide.md
+++ b/docs/client_guide/spark_client_guide.md
@@ -192,3 +192,15 @@ spark.plugins org.apache.spark.UnifflePlugin
 
 To enable this feature in the Spark History Server, place the Uniffle client JAR file into the jars directory of your Spark HOME. 
 A restart of the History Server may be required for the changes to take effect.
+
+### Overlapping compression for shuffle write
+
+This mechanism allows compression to overlap with upstream data reading, maximizing shuffle write throughput. It can improve shuffle write speed by up to 50%. Now this is enabled by default.
+
+The feature can be enabled or disabled through the following configuration:
+
+| Property Name                                          | Default   | Description                                                                                                                                      |
+|--------------------------------------------------------|-----------|--------------------------------------------------------------------------------------------------------------------------------------------------|
+| spark.rss.client.write.overlappingCompressionEnable    | true      | Whether to overlapping compress shuffle blocks.                                                                                                  |
+| rss.client.write.overlappingCompressionThreadsPerVcore | -1        | Specifies the ratio of overlapping compression threads to Spark executor vCores. By default, all cores on the machine are used for compression.  | 
+


### PR DESCRIPTION

### What changes were proposed in this pull request?
1. Enable overlapping compression by default
2. Add doc for this feature

### Why are the changes needed?

for #2494 

### Does this PR introduce _any_ user-facing change?

Yes.

### How was this patch tested?

Needn't