### PR TITLE
[#2575] fix(client-spark): Fix java.lang.IndexOutOfBoundsException: len is negative

### DIFF
--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/reader/RssShuffleDataIterator.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/reader/RssShuffleDataIterator.java
@@ -161,6 +161,10 @@ public class RssShuffleDataIterator<K, C> extends AbstractIterator<Product2<K, C
     shuffleReadMetrics.incRemoteBytesRead(rawDataLength);
 
     int uncompressedLen = rawBlock.getUncompressLength();
+    if (uncompressedLen < 0) {
+        LOG.error("Uncompressed length is negative: {}", uncompressedLen);
+        throw new IllegalArgumentException("Uncompressed length is negative: " + uncompressedLen);
+    }
     if (codec.isPresent()) {
       if (uncompressedData == null
           || uncompressedData.capacity() < uncompressedLen


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix java.lang.IndexOutOfBoundsException: len is negative

### Why are the changes needed?
for https://github.com/apache/uniffle/issues/2575

### Does this PR introduce any user-facing change?
No.

### How was this patch tested?
UT