### PR TITLE
[#2592] fix(spark): Ignore failure when reporting shuffle read metrics to driver

### DIFF
--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/reader/RssShuffleReader.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/reader/RssShuffleReader.java
@@ -367,30 +367,34 @@ public class RssShuffleReader<K, C> implements ShuffleReader<K, C> {
     if (managerClientSupplier != null) {
       ShuffleManagerClient client = managerClientSupplier.get();
       if (client != null) {
-        RssReportShuffleReadMetricResponse response =
-            client.reportShuffleReadMetric(
-                new RssReportShuffleReadMetricRequest(
-                    context.stageId(),
-                    shuffleId,
-                    context.taskAttemptId(),
-                    shuffleServerReadCostTracker.list().entrySet().stream()
-                        .collect(
-                            Collectors.toMap(
-                                Map.Entry::getKey,
-                                x ->
-                                    new RssReportShuffleReadMetricRequest.TaskShuffleReadMetric(
-                                        x.getValue().getDurationMillis(),
-                                        x.getValue().getReadBytes(),
-                                        x.getValue().getMemoryReadDurationMillis(),
-                                        x.getValue().getMemoryReadBytes(),
-                                        x.getValue().getLocalfileReadDurationMillis(),
-                                        x.getValue().getLocalfileReadBytes(),
-                                        x.getValue().getHadoopReadLocalFileDurationMillis(),
-                                        x.getValue().getHadoopReadLocalFileBytes()))),
-                    isShuffleReadFailed,
-                    shuffleReadReason));
-        if (response != null && response.getStatusCode() != StatusCode.SUCCESS) {
-          LOG.error("Errors on reporting shuffle read metrics to driver");
+        try {
+          RssReportShuffleReadMetricResponse response =
+                  client.reportShuffleReadMetric(
+                          new RssReportShuffleReadMetricRequest(
+                                  context.stageId(),
+                                  shuffleId,
+                                  context.taskAttemptId(),
+                                  shuffleServerReadCostTracker.list().entrySet().stream()
+                                          .collect(
+                                                  Collectors.toMap(
+                                                          Map.Entry::getKey,
+                                                          x ->
+                                                                  new RssReportShuffleReadMetricRequest.TaskShuffleReadMetric(
+                                                                          x.getValue().getDurationMillis(),
+                                                                          x.getValue().getReadBytes(),
+                                                                          x.getValue().getMemoryReadDurationMillis(),
+                                                                          x.getValue().getMemoryReadBytes(),
+                                                                          x.getValue().getLocalfileReadDurationMillis(),
+                                                                          x.getValue().getLocalfileReadBytes(),
+                                                                          x.getValue().getHadoopReadLocalFileDurationMillis(),
+                                                                          x.getValue().getHadoopReadLocalFileBytes()))),
+                                  isShuffleReadFailed,
+                                  shuffleReadReason));
+          if (response != null && response.getStatusCode() != StatusCode.SUCCESS) {
+            LOG.error("Errors on reporting shuffle read metrics to driver");
+          }
+        } catch (Exception e) {
+          LOG.error("Errors on post shuffle read metric to driver", e);
         }
       }
     }

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/reader/RssShuffleReader.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/reader/RssShuffleReader.java
@@ -369,27 +369,27 @@ public class RssShuffleReader<K, C> implements ShuffleReader<K, C> {
       if (client != null) {
         try {
           RssReportShuffleReadMetricResponse response =
-                  client.reportShuffleReadMetric(
-                          new RssReportShuffleReadMetricRequest(
-                                  context.stageId(),
-                                  shuffleId,
-                                  context.taskAttemptId(),
-                                  shuffleServerReadCostTracker.list().entrySet().stream()
-                                          .collect(
-                                                  Collectors.toMap(
-                                                          Map.Entry::getKey,
-                                                          x ->
-                                                                  new RssReportShuffleReadMetricRequest.TaskShuffleReadMetric(
-                                                                          x.getValue().getDurationMillis(),
-                                                                          x.getValue().getReadBytes(),
-                                                                          x.getValue().getMemoryReadDurationMillis(),
-                                                                          x.getValue().getMemoryReadBytes(),
-                                                                          x.getValue().getLocalfileReadDurationMillis(),
-                                                                          x.getValue().getLocalfileReadBytes(),
-                                                                          x.getValue().getHadoopReadLocalFileDurationMillis(),
-                                                                          x.getValue().getHadoopReadLocalFileBytes()))),
-                                  isShuffleReadFailed,
-                                  shuffleReadReason));
+              client.reportShuffleReadMetric(
+                  new RssReportShuffleReadMetricRequest(
+                      context.stageId(),
+                      shuffleId,
+                      context.taskAttemptId(),
+                      shuffleServerReadCostTracker.list().entrySet().stream()
+                          .collect(
+                              Collectors.toMap(
+                                  Map.Entry::getKey,
+                                  x ->
+                                      new RssReportShuffleReadMetricRequest.TaskShuffleReadMetric(
+                                          x.getValue().getDurationMillis(),
+                                          x.getValue().getReadBytes(),
+                                          x.getValue().getMemoryReadDurationMillis(),
+                                          x.getValue().getMemoryReadBytes(),
+                                          x.getValue().getLocalfileReadDurationMillis(),
+                                          x.getValue().getLocalfileReadBytes(),
+                                          x.getValue().getHadoopReadLocalFileDurationMillis(),
+                                          x.getValue().getHadoopReadLocalFileBytes()))),
+                      isShuffleReadFailed,
+                      shuffleReadReason));
           if (response != null && response.getStatusCode() != StatusCode.SUCCESS) {
             LOG.error("Errors on reporting shuffle read metrics to driver");
           }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Ignore failure when reporting shuffle read metrics to driver

### Why are the changes needed?

fix #2592 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Needn't
