### PR TITLE
[#2569] feat(spark): Add statistic of shuffle read times

### DIFF
--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/events/TaskShuffleReadInfoEvent.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/events/TaskShuffleReadInfoEvent.java
@@ -19,6 +19,8 @@ package org.apache.spark.shuffle.events;
 
 import java.util.Map;
 
+import org.apache.uniffle.common.ShuffleReadTimes;
+
 public class TaskShuffleReadInfoEvent extends UniffleEvent {
   private int stageId;
   private int shuffleId;
@@ -26,6 +28,7 @@ public class TaskShuffleReadInfoEvent extends UniffleEvent {
   private Map<String, ShuffleReadMetric> metrics;
   private boolean isShuffleReadFailed;
   private String failureReason;
+  private ShuffleReadTimes shuffleReadTimes;
 
   public TaskShuffleReadInfoEvent(
       int stageId,
@@ -33,13 +36,15 @@ public class TaskShuffleReadInfoEvent extends UniffleEvent {
       long taskId,
       Map<String, ShuffleReadMetric> metrics,
       boolean isShuffleReadFailed,
-      String failureReason) {
+      String failureReason,
+      ShuffleReadTimes shuffleReadTimes) {
     this.stageId = stageId;
     this.shuffleId = shuffleId;
     this.taskId = taskId;
     this.metrics = metrics;
     this.isShuffleReadFailed = isShuffleReadFailed;
     this.failureReason = failureReason;
+    this.shuffleReadTimes = shuffleReadTimes;
   }
 
   public int getStageId() {
@@ -64,5 +69,9 @@ public class TaskShuffleReadInfoEvent extends UniffleEvent {
 
   public String getFailureReason() {
     return failureReason;
+  }
+
+  public ShuffleReadTimes getShuffleReadTimes() {
+    return shuffleReadTimes;
   }
 }

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/reader/RssShuffleDataIterator.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/reader/RssShuffleDataIterator.java
@@ -40,6 +40,7 @@ import org.slf4j.LoggerFactory;
 
 import org.apache.uniffle.client.api.ShuffleReadClient;
 import org.apache.uniffle.client.response.CompressedShuffleBlock;
+import org.apache.uniffle.common.ShuffleReadTimes;
 import org.apache.uniffle.common.compression.Codec;
 import org.apache.uniffle.common.config.RssConf;
 import org.apache.uniffle.common.util.RssUtils;
@@ -229,5 +230,12 @@ public class RssShuffleDataIterator<K, C> extends AbstractIterator<Product2<K, C
   @VisibleForTesting
   protected ShuffleReadMetrics getShuffleReadMetrics() {
     return shuffleReadMetrics;
+  }
+
+  public ShuffleReadTimes getReadTimes() {
+    ShuffleReadTimes times = shuffleReadClient.getShuffleReadTimes();
+    times.withDecompressed(decompressTime);
+    times.withDeserialized(serializeTime);
+    return times;
   }
 }

--- a/client-spark/common/src/main/java/org/apache/uniffle/shuffle/manager/ShuffleManagerGrpcService.java
+++ b/client-spark/common/src/main/java/org/apache/uniffle/shuffle/manager/ShuffleManagerGrpcService.java
@@ -44,6 +44,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.uniffle.common.ReceivingFailureServer;
+import org.apache.uniffle.common.ShuffleReadTimes;
 import org.apache.uniffle.common.ShuffleServerInfo;
 import org.apache.uniffle.common.exception.RssException;
 import org.apache.uniffle.common.util.JavaUtils;
@@ -768,7 +769,8 @@ public class ShuffleManagerGrpcService extends ShuffleManagerImplBase {
                                 x.getValue().getHadoopDurationMillis(),
                                 x.getValue().getHadoopByteSize()))),
             request.getIsTaskReadFailed(),
-            request.getShuffleReadFailureReason());
+            request.getShuffleReadFailureReason(),
+            ShuffleReadTimes.fromProto(request.getShuffleReadTimes()));
     RssSparkShuffleUtils.getActiveSparkContext().listenerBus().post(event);
     RssProtos.ReportShuffleReadMetricResponse reply =
         RssProtos.ReportShuffleReadMetricResponse.newBuilder()

--- a/client-spark/extension/src/main/scala/org/apache/spark/UniffleStatusStore.scala
+++ b/client-spark/extension/src/main/scala/org/apache/spark/UniffleStatusStore.scala
@@ -22,6 +22,7 @@ import org.apache.spark.shuffle.events.{ShuffleWriteTimes, TaskReassignInfoEvent
 import org.apache.spark.status.KVUtils.KVIndexParam
 import org.apache.spark.util.Utils
 import org.apache.spark.util.kvstore.{KVIndex, KVStore, KVStoreView}
+import org.apache.uniffle.common.ShuffleReadTimes
 
 import java.util.concurrent.ConcurrentHashMap
 import scala.collection.JavaConverters.asScalaIteratorConverter
@@ -46,6 +47,15 @@ class UniffleStatusStore(store: KVStore) {
       store.read(kClass, kClass.getName)
     } catch {
       case _: NoSuchElementException => new BuildInfoUIData(Seq.empty)
+    }
+  }
+
+  def shuffleReadTimes(): AggregatedShuffleReadTimesUIData = {
+    val kClass = classOf[AggregatedShuffleReadTimesUIData]
+    try {
+      store.read(kClass, kClass.getName)
+    } catch {
+      case _: NoSuchElementException => AggregatedShuffleReadTimesUIData(new ShuffleReadTimes())
     }
   }
 
@@ -162,6 +172,12 @@ case class AggregatedShuffleWriteTimesUIData(times: ShuffleWriteTimes) {
   @JsonIgnore
   @KVIndex
   def id: String = classOf[AggregatedShuffleWriteTimesUIData].getName()
+}
+
+case class AggregatedShuffleReadTimesUIData(times: ShuffleReadTimes) {
+  @JsonIgnore
+  @KVIndex
+  def id: String = classOf[AggregatedShuffleReadTimesUIData].getName()
 }
 
 case class ReassignInfoUIData(event: TaskReassignInfoEvent) {

--- a/client-spark/extension/src/main/scala/org/apache/spark/ui/ShufflePage.scala
+++ b/client-spark/extension/src/main/scala/org/apache/spark/ui/ShufflePage.scala
@@ -163,7 +163,7 @@ class ShufflePage(parent: ShuffleTab) extends WebUIPage("") with Logging {
       shuffleReadTimesRow,
       Seq(
         Seq(
-          UIUtils.formatDuration(readTimes.getTotal),
+          UIUtils.formatDuration(readTotal),
           UIUtils.formatDuration(readTimes.getFetch),
           UIUtils.formatDuration(readTimes.getCopy),
           UIUtils.formatDuration(readTimes.getCrc),
@@ -171,8 +171,7 @@ class ShufflePage(parent: ShuffleTab) extends WebUIPage("") with Logging {
           UIUtils.formatDuration(readTimes.getDeserialize),
         ),
         Seq(
-          1.toDouble,
-          readTimes.getTotal / readTotal,
+          1,
           readTimes.getFetch.toDouble / readTotal,
           readTimes.getCopy.toDouble / readTotal,
           readTimes.getCrc.toDouble / readTotal,

--- a/client-spark/extension/src/main/scala/org/apache/spark/ui/ShufflePage.scala
+++ b/client-spark/extension/src/main/scala/org/apache/spark/ui/ShufflePage.scala
@@ -40,6 +40,15 @@ class ShufflePage(parent: ShuffleTab) extends WebUIPage("") with Logging {
     </td>
   </tr>
 
+  private def shuffleReadTimesRow(kv: Seq[String]) = <tr>
+    <td>{kv(0)}</td>
+    <td>{kv(1)}</td>
+    <td>{kv(2)}</td>
+    <td>{kv(3)}</td>
+    <td>{kv(4)}</td>
+    <td>{kv(5)}</td>
+  </tr>
+
   private def shuffleWriteTimesRow(kv: Seq[String]) = <tr>
     <td>{kv(0)}</td>
     <td>{kv(1)}</td>
@@ -146,9 +155,37 @@ class ShufflePage(parent: ShuffleTab) extends WebUIPage("") with Logging {
       fixedWidth = true
     )
 
+    // render shuffle read times
+    val readTimes = runtimeStatusStore.shuffleReadTimes().times
+    val readTotal = if (readTimes.getTotal <= 0) -1 else readTimes.getTotal
+    val readTimesUI = UIUtils.listingTable(
+      Seq("Total", "Fetch", "Copy", "CRC", "Decompress", "Deserialize"),
+      shuffleReadTimesRow,
+      Seq(
+        Seq(
+          UIUtils.formatDuration(readTimes.getTotal),
+          UIUtils.formatDuration(readTimes.getFetch),
+          UIUtils.formatDuration(readTimes.getCopy),
+          UIUtils.formatDuration(readTimes.getCrc),
+          UIUtils.formatDuration(readTimes.getDecompress),
+          UIUtils.formatDuration(readTimes.getDeserialize),
+        ),
+        Seq(
+          1.toDouble,
+          readTimes.getTotal / readTotal,
+          readTimes.getFetch.toDouble / readTotal,
+          readTimes.getCopy.toDouble / readTotal,
+          readTimes.getCrc.toDouble / readTotal,
+          readTimes.getDecompress.toDouble / readTotal,
+          readTimes.getDeserialize.toDouble / readTotal,
+        ).map(x => roundToTwoDecimals(x).toString)
+      ),
+      fixedWidth = true
+    )
+
     // render shuffle write times
     val writeTimes = runtimeStatusStore.shuffleWriteTimes().times
-    val total = if (writeTimes.getTotal <= 0) -1 else writeTimes.getTotal
+    val writeTotal = if (writeTimes.getTotal <= 0) -1 else writeTimes.getTotal
     val writeTimesUI = UIUtils.listingTable(
       Seq("Total Time", "Wait Finish Time", "Copy Time", "Serialize Time", "Compress Time", "Sort Time", "Require Memory Time"),
       shuffleWriteTimesRow,
@@ -164,12 +201,12 @@ class ShufflePage(parent: ShuffleTab) extends WebUIPage("") with Logging {
         ),
         Seq(
           1.toDouble,
-          writeTimes.getWaitFinish.toDouble / total,
-          writeTimes.getCopy.toDouble / total,
-          writeTimes.getSerialize.toDouble / total,
-          writeTimes.getCompress.toDouble / total,
-          writeTimes.getSort.toDouble / total,
-          writeTimes.getRequireMemory.toDouble / total,
+          writeTimes.getWaitFinish.toDouble / writeTotal,
+          writeTimes.getCopy.toDouble / writeTotal,
+          writeTimes.getSerialize.toDouble / writeTotal,
+          writeTimes.getCompress.toDouble / writeTotal,
+          writeTimes.getSort.toDouble / writeTotal,
+          writeTimes.getRequireMemory.toDouble / writeTotal,
         ).map(x => roundToTwoDecimals(x).toString)
       ),
       fixedWidth = true
@@ -405,6 +442,19 @@ class ShufflePage(parent: ShuffleTab) extends WebUIPage("") with Logging {
           </span>
           <div class="write-times-table collapsible-table collapsed">
             {writeTimesUI}
+          </div>
+        </div>
+
+        <div>
+          <span class="collapse-read-times-properties collapse-table"
+                onClick="collapseTable('collapse-read-times-properties', 'read-times-table')">
+            <h4>
+              <span class="collapse-table-arrow arrow-closed"></span>
+              <a>Shuffle Read Times</a>
+            </h4>
+          </span>
+          <div class="read-times-table collapsible-table collapsed">
+            {readTimesUI}
           </div>
         </div>
       </div>

--- a/client/src/main/java/org/apache/uniffle/client/api/ShuffleReadClient.java
+++ b/client/src/main/java/org/apache/uniffle/client/api/ShuffleReadClient.java
@@ -18,6 +18,7 @@
 package org.apache.uniffle.client.api;
 
 import org.apache.uniffle.client.response.CompressedShuffleBlock;
+import org.apache.uniffle.common.ShuffleReadTimes;
 
 public interface ShuffleReadClient {
 
@@ -28,4 +29,6 @@ public interface ShuffleReadClient {
   void close();
 
   void logStatics();
+
+  ShuffleReadTimes getShuffleReadTimes();
 }

--- a/client/src/main/java/org/apache/uniffle/client/impl/ShuffleReadClientImpl.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/ShuffleReadClientImpl.java
@@ -40,6 +40,7 @@ import org.apache.uniffle.client.util.DefaultIdHelper;
 import org.apache.uniffle.common.BufferSegment;
 import org.apache.uniffle.common.ShuffleDataDistributionType;
 import org.apache.uniffle.common.ShuffleDataResult;
+import org.apache.uniffle.common.ShuffleReadTimes;
 import org.apache.uniffle.common.ShuffleServerInfo;
 import org.apache.uniffle.common.config.RssClientConf;
 import org.apache.uniffle.common.config.RssConf;
@@ -355,5 +356,10 @@ public class ShuffleReadClientImpl implements ShuffleReadClient {
             + crcCheckTime
             + " ms");
     clientReadHandler.logConsumedBlockInfo();
+  }
+
+  @Override
+  public ShuffleReadTimes getShuffleReadTimes() {
+    return new ShuffleReadTimes(readDataTime.get(), copyTime.get(), crcCheckTime.get());
   }
 }

--- a/common/src/main/java/org/apache/uniffle/common/ShuffleReadTimes.java
+++ b/common/src/main/java/org/apache/uniffle/common/ShuffleReadTimes.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.uniffle.common;
+
+import org.apache.uniffle.proto.RssProtos;
+
+/** The unit is millis */
+public class ShuffleReadTimes {
+  private long fetch;
+  private long crc;
+  private long copy;
+  private long deserialize;
+  private long decompress;
+
+  public ShuffleReadTimes() {}
+
+  public ShuffleReadTimes(long fetch, long crc, long copy) {
+    this.fetch = fetch;
+    this.crc = crc;
+    this.copy = copy;
+  }
+
+  public long getFetch() {
+    return fetch;
+  }
+
+  public long getCrc() {
+    return crc;
+  }
+
+  public long getCopy() {
+    return copy;
+  }
+
+  public void withDeserialized(long deserialized) {
+    this.deserialize = deserialized;
+  }
+
+  public void withDecompressed(long decompressed) {
+    this.decompress = decompressed;
+  }
+
+  public long getDeserialize() {
+    return deserialize;
+  }
+
+  public long getDecompress() {
+    return decompress;
+  }
+
+  public void merge(ShuffleReadTimes other) {
+    this.fetch += other.fetch;
+    this.crc += other.crc;
+    this.copy += other.copy;
+    this.deserialize += other.deserialize;
+    this.decompress += other.decompress;
+  }
+
+  public long getTotal() {
+    return fetch + crc + copy + deserialize + decompress;
+  }
+
+  public RssProtos.ShuffleReadTimes toProto() {
+    return RssProtos.ShuffleReadTimes.newBuilder()
+        .setFetch(fetch)
+        .setCrc(crc)
+        .setCopy(copy)
+        .setDecompress(decompress)
+        .setDeserialize(deserialize)
+        .build();
+  }
+
+  public static ShuffleReadTimes fromProto(RssProtos.ShuffleReadTimes proto) {
+    ShuffleReadTimes time = new ShuffleReadTimes();
+    time.fetch = proto.getFetch();
+    time.crc = proto.getCrc();
+    time.copy = proto.getCopy();
+    time.decompress = proto.getDecompress();
+    time.deserialize = proto.getDeserialize();
+    return time;
+  }
+}

--- a/internal-client/src/main/java/org/apache/uniffle/client/request/RssReportShuffleReadMetricRequest.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/request/RssReportShuffleReadMetricRequest.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import org.apache.uniffle.common.ShuffleReadTimes;
 import org.apache.uniffle.proto.RssProtos;
 
 public class RssReportShuffleReadMetricRequest {
@@ -30,6 +31,7 @@ public class RssReportShuffleReadMetricRequest {
   private Map<String, TaskShuffleReadMetric> metrics;
   private boolean isShuffleReadFailed;
   private Optional<String> shuffleReadReason;
+  private ShuffleReadTimes shuffleReadTimes;
 
   public RssReportShuffleReadMetricRequest(
       int stageId,
@@ -37,13 +39,15 @@ public class RssReportShuffleReadMetricRequest {
       long taskId,
       Map<String, TaskShuffleReadMetric> metrics,
       boolean isShuffleReadFailed,
-      Optional<String> shuffleReadReason) {
+      Optional<String> shuffleReadReason,
+      ShuffleReadTimes shuffleReadTimes) {
     this.stageId = stageId;
     this.shuffleId = shuffleId;
     this.taskId = taskId;
     this.metrics = metrics;
     this.isShuffleReadFailed = isShuffleReadFailed;
     this.shuffleReadReason = shuffleReadReason;
+    this.shuffleReadTimes = shuffleReadTimes;
   }
 
   public RssProtos.ReportShuffleReadMetricRequest toProto() {
@@ -56,6 +60,7 @@ public class RssReportShuffleReadMetricRequest {
         .setTaskId(request.taskId)
         .setIsTaskReadFailed(request.isShuffleReadFailed)
         .setShuffleReadFailureReason(request.shuffleReadReason.orElse(""))
+        .setShuffleReadTimes(shuffleReadTimes.toProto())
         .putAllMetrics(
             request.metrics.entrySet().stream()
                 .collect(

--- a/proto/src/main/proto/Rss.proto
+++ b/proto/src/main/proto/Rss.proto
@@ -641,6 +641,15 @@ message ReportShuffleReadMetricRequest {
   map<string, ShuffleReadMetric> metrics = 4;
   bool isTaskReadFailed = 5;
   string shuffleReadFailureReason = 6;
+  ShuffleReadTimes shuffleReadTimes = 7;
+}
+
+message ShuffleReadTimes {
+  int64 fetch = 1;
+  int64 crc = 2;
+  int64 copy = 3;
+  int64 deserialize = 4;
+  int64 decompress = 5;
 }
 
 message ReportShuffleReadMetricResponse {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add statistic of shuffle read times to find the bottleneck for shuffle reading

### Why are the changes needed?

for #2569

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Tests in cluster
