### PR TITLE
[#2601] feat(spark): Overlapping decompression for shuffle read

### DIFF
--- a/client-mr/core/src/main/java/org/apache/hadoop/mapreduce/task/reduce/RssFetcher.java
+++ b/client-mr/core/src/main/java/org/apache/hadoop/mapreduce/task/reduce/RssFetcher.java
@@ -153,7 +153,7 @@ public class RssFetcher<K, V> {
     // fetch a block
     if (!hasPendingData) {
       final long startFetch = System.currentTimeMillis();
-      compressedBlock = shuffleReadClient.readShuffleBlockData();
+      compressedBlock = (CompressedShuffleBlock) (shuffleReadClient.readShuffleBlockData());
       if (compressedBlock != null) {
         compressedData = compressedBlock.getByteBuffer();
       }

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/RssSparkConfig.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/RssSparkConfig.java
@@ -39,6 +39,18 @@ import org.apache.uniffle.common.config.RssConf;
 
 public class RssSparkConfig {
 
+  public static final ConfigOption<Boolean> RSS_READ_OVERLAPPING_DECOMPRESSION_ENABLED =
+      ConfigOptions.key("rss.client.read.overlappingDecompressionEnable")
+          .booleanType()
+          .defaultValue(true)
+          .withDescription("Whether to overlapping decompress shuffle blocks.");
+
+  public static final ConfigOption<Integer> RSS_READ_OVERLAPPING_DECOMPRESSION_THREADS =
+      ConfigOptions.key("rss.client.read.overlappingDecompressionThreads")
+          .intType()
+          .defaultValue(1)
+          .withDescription("Number of threads to use for overlapping decompress shuffle blocks.");
+
   public static final ConfigOption<Boolean> RSS_WRITE_OVERLAPPING_COMPRESSION_ENABLED =
       ConfigOptions.key("rss.client.write.overlappingCompressionEnable")
           .booleanType()

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/RssSparkConfig.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/RssSparkConfig.java
@@ -42,7 +42,7 @@ public class RssSparkConfig {
   public static final ConfigOption<Boolean> RSS_READ_OVERLAPPING_DECOMPRESSION_ENABLED =
       ConfigOptions.key("rss.client.read.overlappingDecompressionEnable")
           .booleanType()
-          .defaultValue(true)
+          .defaultValue(false)
           .withDescription("Whether to overlapping decompress shuffle blocks.");
 
   public static final ConfigOption<Integer> RSS_READ_OVERLAPPING_DECOMPRESSION_THREADS =

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/reader/RssShuffleDataIterator.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/reader/RssShuffleDataIterator.java
@@ -139,9 +139,10 @@ public class RssShuffleDataIterator<K, C> extends AbstractIterator<Product2<K, C
         shuffleReadMetrics.incRemoteBytesRead(rawDataLength);
 
         // get initial data
-        ByteBuffer decompressed = uncompressedData;
+        ByteBuffer decompressed = null;
         if (shuffleBlock instanceof CompressedShuffleBlock) {
           uncompress(shuffleBlock, rawData);
+          decompressed = uncompressedData;
         } else {
           decompressed = shuffleBlock.getByteBuffer();
         }

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/reader/RssShuffleDataIterator.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/reader/RssShuffleDataIterator.java
@@ -40,6 +40,7 @@ import org.slf4j.LoggerFactory;
 
 import org.apache.uniffle.client.api.ShuffleReadClient;
 import org.apache.uniffle.client.response.CompressedShuffleBlock;
+import org.apache.uniffle.client.response.ShuffleBlock;
 import org.apache.uniffle.common.ShuffleReadTimes;
 import org.apache.uniffle.common.compression.Codec;
 import org.apache.uniffle.common.config.RssConf;
@@ -63,20 +64,32 @@ public class RssShuffleDataIterator<K, C> extends AbstractIterator<Product2<K, C
   private ByteBuffer uncompressedData;
   private Optional<Codec> codec;
 
+  // only for tests
+  @VisibleForTesting
   public RssShuffleDataIterator(
       Serializer serializer,
       ShuffleReadClient shuffleReadClient,
       ShuffleReadMetrics shuffleReadMetrics,
       RssConf rssConf) {
-    this.serializerInstance = serializer.newInstance();
-    this.shuffleReadClient = shuffleReadClient;
-    this.shuffleReadMetrics = shuffleReadMetrics;
+    this(serializer, shuffleReadClient, shuffleReadMetrics, rssConf, Optional.empty());
     boolean compress =
         rssConf.getBoolean(
             RssSparkConfig.SPARK_SHUFFLE_COMPRESS_KEY.substring(
                 RssSparkConfig.SPARK_RSS_CONFIG_PREFIX.length()),
             RssSparkConfig.SPARK_SHUFFLE_COMPRESS_DEFAULT);
     this.codec = compress ? Codec.newInstance(rssConf) : Optional.empty();
+  }
+
+  public RssShuffleDataIterator(
+      Serializer serializer,
+      ShuffleReadClient shuffleReadClient,
+      ShuffleReadMetrics shuffleReadMetrics,
+      RssConf rssConf,
+      Optional<Codec> codec) {
+    this.serializerInstance = serializer.newInstance();
+    this.shuffleReadClient = shuffleReadClient;
+    this.shuffleReadMetrics = shuffleReadMetrics;
+    this.codec = codec;
   }
 
   public Iterator<Tuple2<Object, Object>> createKVIterator(ByteBuffer data) {
@@ -114,17 +127,28 @@ public class RssShuffleDataIterator<K, C> extends AbstractIterator<Product2<K, C
       // read next segment
       long startFetch = System.currentTimeMillis();
       // depends on spark.shuffle.compress, shuffled block may not be compressed
-      CompressedShuffleBlock rawBlock = shuffleReadClient.readShuffleBlockData();
-      // If ShuffleServer delete
+      ShuffleBlock shuffleBlock = shuffleReadClient.readShuffleBlockData();
+      ByteBuffer rawData = shuffleBlock != null ? shuffleBlock.getByteBuffer() : null;
 
-      ByteBuffer rawData = rawBlock != null ? rawBlock.getByteBuffer() : null;
       long fetchDuration = System.currentTimeMillis() - startFetch;
       shuffleReadMetrics.incFetchWaitTime(fetchDuration);
       if (rawData != null) {
-        uncompress(rawBlock, rawData);
+        // collect metrics from raw data
+        long rawDataLength = rawData.limit() - rawData.position();
+        totalRawBytesLength += rawDataLength;
+        shuffleReadMetrics.incRemoteBytesRead(rawDataLength);
+
+        // get initial data
+        ByteBuffer decompressed = uncompressedData;
+        if (shuffleBlock instanceof CompressedShuffleBlock) {
+          uncompress(shuffleBlock, rawData);
+        } else {
+          decompressed = shuffleBlock.getByteBuffer();
+        }
+
         // create new iterator for shuffle data
         long startSerialization = System.currentTimeMillis();
-        recordsIterator = createKVIterator(uncompressedData);
+        recordsIterator = createKVIterator(decompressed);
         long serializationDuration = System.currentTimeMillis() - startSerialization;
         readTime += fetchDuration;
         serializeTime += serializationDuration;
@@ -156,11 +180,7 @@ public class RssShuffleDataIterator<K, C> extends AbstractIterator<Product2<K, C
     return left.isDirect() == right.isDirect();
   }
 
-  private int uncompress(CompressedShuffleBlock rawBlock, ByteBuffer rawData) {
-    long rawDataLength = rawData.limit() - rawData.position();
-    totalRawBytesLength += rawDataLength;
-    shuffleReadMetrics.incRemoteBytesRead(rawDataLength);
-
+  private int uncompress(ShuffleBlock rawBlock, ByteBuffer rawData) {
     int uncompressedLen = rawBlock.getUncompressLength();
     if (uncompressedLen < 0) {
       LOG.error("Uncompressed length is negative: {}", uncompressedLen);

--- a/client-tez/src/main/java/org/apache/tez/runtime/library/common/shuffle/impl/RssTezFetcher.java
+++ b/client-tez/src/main/java/org/apache/tez/runtime/library/common/shuffle/impl/RssTezFetcher.java
@@ -101,7 +101,7 @@ public class RssTezFetcher {
     if (!hasPendingData) {
       final long startFetch = System.currentTimeMillis();
       blockStartFetch = System.currentTimeMillis();
-      compressedBlock = shuffleReadClient.readShuffleBlockData();
+      compressedBlock = (CompressedShuffleBlock) (shuffleReadClient.readShuffleBlockData());
       if (compressedBlock != null) {
         compressedData = compressedBlock.getByteBuffer();
       }

--- a/client-tez/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/RssTezShuffleDataFetcher.java
+++ b/client-tez/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/RssTezShuffleDataFetcher.java
@@ -143,7 +143,7 @@ public class RssTezShuffleDataFetcher extends CallableWithNdc<Void> {
     // fetch a block
     if (!hasPendingData) {
       final long startFetch = System.currentTimeMillis();
-      compressedBlock = shuffleReadClient.readShuffleBlockData();
+      compressedBlock = (CompressedShuffleBlock) (shuffleReadClient.readShuffleBlockData());
       if (compressedBlock != null) {
         compressedData = compressedBlock.getByteBuffer();
       }

--- a/client/src/main/java/org/apache/uniffle/client/api/ShuffleReadClient.java
+++ b/client/src/main/java/org/apache/uniffle/client/api/ShuffleReadClient.java
@@ -17,12 +17,12 @@
 
 package org.apache.uniffle.client.api;
 
-import org.apache.uniffle.client.response.CompressedShuffleBlock;
+import org.apache.uniffle.client.response.ShuffleBlock;
 import org.apache.uniffle.common.ShuffleReadTimes;
 
 public interface ShuffleReadClient {
 
-  CompressedShuffleBlock readShuffleBlockData();
+  ShuffleBlock readShuffleBlockData();
 
   void checkProcessedBlockIds();
 

--- a/client/src/main/java/org/apache/uniffle/client/factory/ShuffleClientFactory.java
+++ b/client/src/main/java/org/apache/uniffle/client/factory/ShuffleClientFactory.java
@@ -29,6 +29,7 @@ import org.apache.uniffle.client.impl.ShuffleWriteClientImpl;
 import org.apache.uniffle.common.ClientType;
 import org.apache.uniffle.common.ShuffleDataDistributionType;
 import org.apache.uniffle.common.ShuffleServerInfo;
+import org.apache.uniffle.common.compression.Codec;
 import org.apache.uniffle.common.config.RssConf;
 import org.apache.uniffle.common.util.IdHelper;
 import org.apache.uniffle.storage.handler.impl.ShuffleServerReadCostTracker;
@@ -226,6 +227,27 @@ public class ShuffleClientFactory {
     private int retryMax;
     private long retryIntervalMax;
     private ShuffleServerReadCostTracker readCostTracker;
+
+    private boolean overlappingDecompressionEnabled;
+    private int overlappingDecompressionThreadNum;
+    private Codec codec;
+
+    public ReadClientBuilder overlappingDecompressionEnabled(
+        boolean overlappingDecompressionEnabled) {
+      this.overlappingDecompressionEnabled = overlappingDecompressionEnabled;
+      return this;
+    }
+
+    public ReadClientBuilder overlappingDecompressionThreadNum(
+        int overlappingDecompressionThreadNum) {
+      this.overlappingDecompressionThreadNum = overlappingDecompressionThreadNum;
+      return this;
+    }
+
+    public ReadClientBuilder codec(Codec codec) {
+      this.codec = codec;
+      return this;
+    }
 
     public ReadClientBuilder readCostTracker(ShuffleServerReadCostTracker tracker) {
       this.readCostTracker = tracker;
@@ -427,6 +449,18 @@ public class ShuffleClientFactory {
 
     public long getRetryIntervalMax() {
       return retryIntervalMax;
+    }
+
+    public boolean isOverlappingDecompressionEnabled() {
+      return overlappingDecompressionEnabled;
+    }
+
+    public int getOverlappingDecompressionThreadNum() {
+      return overlappingDecompressionThreadNum;
+    }
+
+    public Codec getCodec() {
+      return codec;
     }
 
     public ShuffleReadClientImpl build() {

--- a/client/src/main/java/org/apache/uniffle/client/impl/DecompressionWorker.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/DecompressionWorker.java
@@ -59,7 +59,10 @@ public class DecompressionWorker {
     List<BufferSegment> bufferSegments = shuffleDataResult.getBufferSegments();
     ByteBuffer sharedByteBuffer = shuffleDataResult.getDataBuffer();
     int index = 0;
-    LOG.info("Adding {} buffers to decompression worker", bufferSegments.size());
+    LOG.info(
+        "Adding {} segments with batch index:{} to decompression worker",
+        bufferSegments.size(),
+        batchIndex);
     for (BufferSegment bufferSegment : bufferSegments) {
       CompletableFuture<ByteBuffer> f =
           CompletableFuture.supplyAsync(
@@ -73,7 +76,10 @@ public class DecompressionWorker {
                 int uncompressedLen = bufferSegment.getUncompressLength();
                 ByteBuffer dst = bufferLocal.get();
                 if (dst.capacity() < uncompressedLen) {
-                  dst = ByteBuffer.allocate(uncompressedLen);
+                  dst =
+                      dst.isDirect()
+                          ? ByteBuffer.allocateDirect(uncompressedLen)
+                          : ByteBuffer.allocate(uncompressedLen);
                   bufferLocal.set(dst);
                 }
                 dst.clear();

--- a/client/src/main/java/org/apache/uniffle/client/impl/DecompressionWorker.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/DecompressionWorker.java
@@ -59,7 +59,7 @@ public class DecompressionWorker {
     List<BufferSegment> bufferSegments = shuffleDataResult.getBufferSegments();
     ByteBuffer sharedByteBuffer = shuffleDataResult.getDataBuffer();
     int index = 0;
-    LOG.info(
+    LOG.debug(
         "Adding {} segments with batch index:{} to decompression worker",
         bufferSegments.size(),
         batchIndex);
@@ -74,17 +74,10 @@ public class DecompressionWorker {
                 buffer.limit(offset + length);
 
                 int uncompressedLen = bufferSegment.getUncompressLength();
-                ByteBuffer dst = bufferLocal.get();
-                if (dst.capacity() < uncompressedLen) {
-                  dst =
-                      dst.isDirect()
-                          ? ByteBuffer.allocateDirect(uncompressedLen)
-                          : ByteBuffer.allocate(uncompressedLen);
-                  bufferLocal.set(dst);
-                }
-                dst.clear();
-                dst.limit(uncompressedLen);
-
+                ByteBuffer dst =
+                    buffer.isDirect()
+                        ? ByteBuffer.allocateDirect(uncompressedLen)
+                        : ByteBuffer.allocate(uncompressedLen);
                 codec.decompress(buffer, uncompressedLen, dst, 0);
                 return dst;
               },

--- a/client/src/main/java/org/apache/uniffle/client/impl/DecompressionWorker.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/DecompressionWorker.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.uniffle.client.impl;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.uniffle.client.response.DecompressedShuffleBlock;
+import org.apache.uniffle.common.BufferSegment;
+import org.apache.uniffle.common.ShuffleDataResult;
+import org.apache.uniffle.common.compression.Codec;
+import org.apache.uniffle.common.util.JavaUtils;
+
+public class DecompressionWorker {
+  private static final Logger LOG = LoggerFactory.getLogger(DecompressionWorker.class);
+
+  private final ExecutorService executorService;
+  private final ConcurrentHashMap<Integer, ConcurrentHashMap<Integer, DecompressedShuffleBlock>>
+      tasks;
+
+  private Codec codec;
+
+  public DecompressionWorker(Codec codec, int threads) {
+    if (codec == null) {
+      throw new IllegalArgumentException("Codec cannot be null");
+    }
+    if (threads <= 0) {
+      throw new IllegalArgumentException("Threads must be greater than 0");
+    }
+    this.tasks = JavaUtils.newConcurrentMap();
+    this.executorService = Executors.newFixedThreadPool(threads);
+    this.codec = codec;
+  }
+
+  public void add(int batchIndex, ShuffleDataResult shuffleDataResult) {
+    List<BufferSegment> bufferSegments = shuffleDataResult.getBufferSegments();
+    ByteBuffer sharedByteBuffer = shuffleDataResult.getDataBuffer();
+    int index = 0;
+    for (BufferSegment bufferSegment : bufferSegments) {
+      CompletableFuture<ByteBuffer> f =
+          CompletableFuture.supplyAsync(
+              () -> {
+                int offset = bufferSegment.getOffset();
+                int length = bufferSegment.getLength();
+                ByteBuffer buffer = sharedByteBuffer.duplicate();
+                buffer.position(offset);
+                buffer.limit(offset + length);
+
+                // todo: reuse buffer for better performance
+                int uncompressedLen = bufferSegment.getUncompressLength();
+                ByteBuffer dst = ByteBuffer.allocate(uncompressedLen);
+                codec.decompress(buffer, uncompressedLen, dst, 0);
+                return dst;
+              },
+              executorService);
+      ConcurrentHashMap<Integer, DecompressedShuffleBlock> blocks =
+          tasks.computeIfAbsent(batchIndex, k -> new ConcurrentHashMap<>());
+      blocks.put(index++, new DecompressedShuffleBlock(f));
+    }
+  }
+
+  public DecompressedShuffleBlock get(int batchIndex, int segmentIndex) {
+    ConcurrentHashMap<Integer, DecompressedShuffleBlock> blocks = tasks.get(batchIndex);
+    if (blocks == null) {
+      return null;
+    }
+    DecompressedShuffleBlock block = blocks.remove(segmentIndex);
+    return block;
+  }
+}

--- a/client/src/main/java/org/apache/uniffle/client/impl/ShuffleReadClientImpl.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/ShuffleReadClientImpl.java
@@ -321,7 +321,7 @@ public class ShuffleReadClientImpl implements ShuffleReadClient {
   }
 
   private int read() {
-    long start = System.currentTimeMillis();
+    final long start = System.currentTimeMillis();
     // In order to avoid copying, we postpone the release here instead of in the Decoder.
     // RssUtils.releaseByteBuffer(readBuffer) cannot actually release the memory,
     // because PlatformDependent.freeDirectBuffer can only release the ByteBuffer with cleaner.

--- a/client/src/main/java/org/apache/uniffle/client/impl/ShuffleReadClientImpl.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/ShuffleReadClientImpl.java
@@ -36,6 +36,8 @@ import org.slf4j.LoggerFactory;
 import org.apache.uniffle.client.api.ShuffleReadClient;
 import org.apache.uniffle.client.factory.ShuffleClientFactory;
 import org.apache.uniffle.client.response.CompressedShuffleBlock;
+import org.apache.uniffle.client.response.DecompressedShuffleBlock;
+import org.apache.uniffle.client.response.ShuffleBlock;
 import org.apache.uniffle.client.util.DefaultIdHelper;
 import org.apache.uniffle.common.BufferSegment;
 import org.apache.uniffle.common.ShuffleDataDistributionType;
@@ -44,6 +46,7 @@ import org.apache.uniffle.common.ShuffleReadTimes;
 import org.apache.uniffle.common.ShuffleServerInfo;
 import org.apache.uniffle.common.config.RssClientConf;
 import org.apache.uniffle.common.config.RssConf;
+import org.apache.uniffle.common.exception.RssException;
 import org.apache.uniffle.common.exception.RssFetchFailedException;
 import org.apache.uniffle.common.util.BlockIdLayout;
 import org.apache.uniffle.common.util.ChecksumUtils;
@@ -74,6 +77,10 @@ public class ShuffleReadClientImpl implements ShuffleReadClient {
   private IdHelper idHelper;
   private BlockIdLayout blockIdLayout;
   private ShuffleServerReadCostTracker readCostTracker;
+
+  private DecompressionWorker decompressionWorker;
+  private int batchIndex = 0;
+  private int segmentIndex = 0;
 
   public ShuffleReadClientImpl(ShuffleClientFactory.ReadClientBuilder builder) {
     // add default value
@@ -149,6 +156,11 @@ public class ShuffleReadClientImpl implements ShuffleReadClient {
   }
 
   private void init(ShuffleClientFactory.ReadClientBuilder builder) {
+    if (builder.isOverlappingDecompressionEnabled()) {
+      this.decompressionWorker =
+          new DecompressionWorker(
+              builder.getCodec(), builder.getOverlappingDecompressionThreadNum());
+    }
     this.shuffleId = builder.getShuffleId();
     this.partitionId = builder.getPartitionId();
     this.blockIdBitmap = builder.getBlockIdBitmap();
@@ -206,7 +218,7 @@ public class ShuffleReadClientImpl implements ShuffleReadClient {
   }
 
   @Override
-  public CompressedShuffleBlock readShuffleBlockData() {
+  public ShuffleBlock readShuffleBlockData() {
     while (true) {
       // empty data expected, just return null
       if (blockIdBitmap.isEmpty()) {
@@ -286,10 +298,18 @@ public class ShuffleReadClientImpl implements ShuffleReadClient {
       }
 
       if (bs != null) {
-        ByteBuffer compressedBuffer = readBuffer.duplicate();
-        compressedBuffer.position(bs.getOffset());
-        compressedBuffer.limit(bs.getOffset() + bs.getLength());
-        return new CompressedShuffleBlock(compressedBuffer, bs.getUncompressLength());
+        if (decompressionWorker == null) {
+          ByteBuffer compressedBuffer = readBuffer.duplicate();
+          compressedBuffer.position(bs.getOffset());
+          compressedBuffer.limit(bs.getOffset() + bs.getLength());
+          return new CompressedShuffleBlock(compressedBuffer, bs.getUncompressLength());
+        } else {
+          DecompressedShuffleBlock block = decompressionWorker.get(batchIndex - 1, segmentIndex++);
+          if (block == null) {
+            throw new RssException("Should not happen that missing block!");
+          }
+          return block;
+        }
       }
       // current segment hasn't data, try next segment
     }
@@ -312,7 +332,12 @@ public class ShuffleReadClientImpl implements ShuffleReadClient {
       // when an exception is thrown by clientReadHandler.readShuffleData().
       sdr = null;
     }
-    sdr = clientReadHandler.readShuffleData();
+    final ShuffleDataResult shuffleDataResult = clientReadHandler.readShuffleData();
+    if (decompressionWorker != null) {
+      decompressionWorker.add(batchIndex++, shuffleDataResult);
+      segmentIndex = 0;
+    }
+    sdr = shuffleDataResult;
     readDataTime.addAndGet(System.currentTimeMillis() - start);
     if (sdr == null) {
       return 0;

--- a/client/src/main/java/org/apache/uniffle/client/impl/ShuffleReadClientImpl.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/ShuffleReadClientImpl.java
@@ -363,6 +363,9 @@ public class ShuffleReadClientImpl implements ShuffleReadClient {
     if (clientReadHandler != null) {
       clientReadHandler.close();
     }
+    if (decompressionWorker != null) {
+      decompressionWorker.close();
+    }
   }
 
   @Override

--- a/client/src/main/java/org/apache/uniffle/client/response/DecompressedShuffleBlock.java
+++ b/client/src/main/java/org/apache/uniffle/client/response/DecompressedShuffleBlock.java
@@ -18,23 +18,29 @@
 package org.apache.uniffle.client.response;
 
 import java.nio.ByteBuffer;
+import java.util.concurrent.CompletableFuture;
 
-public class CompressedShuffleBlock implements ShuffleBlock {
-  private ByteBuffer byteBuffer;
-  private int uncompressLength;
+import org.apache.uniffle.common.exception.RssException;
 
-  public CompressedShuffleBlock(ByteBuffer byteBuffer, int uncompressLength) {
-    this.byteBuffer = byteBuffer;
-    this.uncompressLength = uncompressLength;
+public class DecompressedShuffleBlock implements ShuffleBlock {
+  private CompletableFuture<ByteBuffer> f;
+
+  public DecompressedShuffleBlock(CompletableFuture<ByteBuffer> f) {
+    this.f = f;
   }
 
   @Override
   public int getUncompressLength() {
-    return uncompressLength;
+    ByteBuffer buffer = getByteBuffer();
+    return buffer.limit() - buffer.position();
   }
 
   @Override
   public ByteBuffer getByteBuffer() {
-    return byteBuffer;
+    try {
+      return f.get();
+    } catch (Exception e) {
+      throw new RssException(e);
+    }
   }
 }

--- a/client/src/main/java/org/apache/uniffle/client/response/ShuffleBlock.java
+++ b/client/src/main/java/org/apache/uniffle/client/response/ShuffleBlock.java
@@ -19,22 +19,9 @@ package org.apache.uniffle.client.response;
 
 import java.nio.ByteBuffer;
 
-public class CompressedShuffleBlock implements ShuffleBlock {
-  private ByteBuffer byteBuffer;
-  private int uncompressLength;
+public interface ShuffleBlock {
 
-  public CompressedShuffleBlock(ByteBuffer byteBuffer, int uncompressLength) {
-    this.byteBuffer = byteBuffer;
-    this.uncompressLength = uncompressLength;
-  }
+  int getUncompressLength();
 
-  @Override
-  public int getUncompressLength() {
-    return uncompressLength;
-  }
-
-  @Override
-  public ByteBuffer getByteBuffer() {
-    return byteBuffer;
-  }
+  ByteBuffer getByteBuffer();
 }

--- a/client/src/test/java/org/apache/uniffle/client/TestUtils.java
+++ b/client/src/test/java/org/apache/uniffle/client/TestUtils.java
@@ -23,7 +23,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.uniffle.client.api.ShuffleReadClient;
-import org.apache.uniffle.client.response.CompressedShuffleBlock;
+import org.apache.uniffle.client.response.ShuffleBlock;
 import org.apache.uniffle.common.BufferSegment;
 import org.apache.uniffle.common.ShuffleDataResult;
 
@@ -52,7 +52,7 @@ public class TestUtils {
         }
       }
       assertTrue(match);
-      CompressedShuffleBlock csb = readClient.readShuffleBlockData();
+      ShuffleBlock csb = readClient.readShuffleBlockData();
       if (csb == null) {
         data = null;
       } else {

--- a/client/src/test/java/org/apache/uniffle/client/impl/DecompressionWorkerTest.java
+++ b/client/src/test/java/org/apache/uniffle/client/impl/DecompressionWorkerTest.java
@@ -61,7 +61,7 @@ public class DecompressionWorkerTest {
       ByteBuffer buffer = createByteBuffer(segmentLength);
       ByteBuffer dest = ByteBuffer.wrap(codec.compress(buffer.array()));
       buffers.add(buffer);
-      segments.add(new BufferSegment(i, offset, dest.remaining(), segmentLength, 1, i));
+      segments.add(new BufferSegment(i, offset, dest.remaining(), buffer.remaining(), 1, i));
       offset += dest.remaining();
     }
     ByteBuffer merged = ByteBuffer.allocate(offset);

--- a/client/src/test/java/org/apache/uniffle/client/impl/DecompressionWorkerTest.java
+++ b/client/src/test/java/org/apache/uniffle/client/impl/DecompressionWorkerTest.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.uniffle.client.impl;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import org.junit.jupiter.api.Test;
+
+import org.apache.uniffle.client.response.DecompressedShuffleBlock;
+import org.apache.uniffle.common.BufferSegment;
+import org.apache.uniffle.common.ShuffleDataResult;
+import org.apache.uniffle.common.compression.Codec;
+import org.apache.uniffle.common.config.RssConf;
+
+import static org.apache.uniffle.common.config.RssClientConf.COMPRESSION_TYPE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class DecompressionWorkerTest {
+
+  @Test
+  public void testEmptyGet() throws Exception {
+    DecompressionWorker worker = new DecompressionWorker(Codec.newInstance(new RssConf()).get(), 1);
+    assertNull(worker.get(1, 1));
+  }
+
+  private ByteBuffer createByteBuffer(int size) {
+    ByteBuffer buffer = ByteBuffer.allocate(size);
+    Random random = new Random();
+    for (int i = 0; i < buffer.capacity(); i++) {
+      buffer.put((byte) random.nextInt(256));
+    }
+    buffer.flip();
+    return buffer;
+  }
+
+  private ShuffleDataResult createShuffleDataResult(
+      int segmentSize, Codec codec, int segmentLength) {
+    List<ByteBuffer> buffers = new ArrayList<>();
+    List<BufferSegment> segments = new ArrayList<>();
+    int offset = 0;
+    for (int i = 0; i < segmentSize; i++) {
+      ByteBuffer buffer = createByteBuffer(segmentLength);
+      ByteBuffer dest = ByteBuffer.wrap(codec.compress(buffer.array()));
+      buffers.add(buffer);
+      segments.add(new BufferSegment(i, offset, dest.remaining(), segmentLength, 1, i));
+      offset += dest.remaining();
+    }
+    ByteBuffer merged = ByteBuffer.allocate(offset);
+    for (ByteBuffer b : buffers) {
+      merged.put(b.duplicate());
+    }
+    merged.flip();
+    return new ShuffleDataResult(merged, segments);
+  }
+
+  @Test
+  public void test() throws Exception {
+    RssConf rssConf = new RssConf();
+    rssConf.set(COMPRESSION_TYPE, Codec.Type.NOOP);
+    Codec codec = Codec.newInstance(rssConf).get();
+    DecompressionWorker worker = new DecompressionWorker(codec, 1);
+
+    // create some data
+    ShuffleDataResult shuffleDataResult = createShuffleDataResult(10, codec, 100);
+    worker.add(0, shuffleDataResult);
+
+    DecompressedShuffleBlock block1 = worker.get(0, 1);
+    assertEquals(100, block1.getByteBuffer().remaining());
+  }
+}

--- a/client/src/test/java/org/apache/uniffle/client/impl/ShuffleReadClientImplTest.java
+++ b/client/src/test/java/org/apache/uniffle/client/impl/ShuffleReadClientImplTest.java
@@ -35,7 +35,7 @@ import org.roaringbitmap.longlong.Roaring64NavigableMap;
 
 import org.apache.uniffle.client.TestUtils;
 import org.apache.uniffle.client.factory.ShuffleClientFactory;
-import org.apache.uniffle.client.response.CompressedShuffleBlock;
+import org.apache.uniffle.client.response.ShuffleBlock;
 import org.apache.uniffle.common.ClientType;
 import org.apache.uniffle.common.ShufflePartitionedBlock;
 import org.apache.uniffle.common.ShuffleServerInfo;
@@ -366,7 +366,7 @@ public class ShuffleReadClientImplTest extends HadoopTestBase {
             e.getMessage());
       }
 
-      CompressedShuffleBlock block = readClient2.readShuffleBlockData();
+      ShuffleBlock block = readClient2.readShuffleBlockData();
       assertNull(block);
     }
     readClient.close();

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/HybridStorageFaultToleranceBase.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/HybridStorageFaultToleranceBase.java
@@ -44,8 +44,8 @@ import org.apache.uniffle.client.request.RssRegisterShuffleRequest;
 import org.apache.uniffle.client.request.RssReportShuffleResultRequest;
 import org.apache.uniffle.client.request.RssSendCommitRequest;
 import org.apache.uniffle.client.request.RssSendShuffleDataRequest;
-import org.apache.uniffle.client.response.CompressedShuffleBlock;
 import org.apache.uniffle.client.response.RssSendShuffleDataResponse;
+import org.apache.uniffle.client.response.ShuffleBlock;
 import org.apache.uniffle.common.ClientType;
 import org.apache.uniffle.common.PartitionRange;
 import org.apache.uniffle.common.ShuffleBlockInfo;
@@ -180,7 +180,7 @@ public abstract class HybridStorageFaultToleranceBase extends ShuffleReadWriteBa
             .shuffleServerInfoList(Lists.newArrayList(ssi))
             .hadoopConf(conf)
             .build();
-    CompressedShuffleBlock csb = readClient.readShuffleBlockData();
+    ShuffleBlock csb = readClient.readShuffleBlockData();
     Roaring64NavigableMap matched = Roaring64NavigableMap.bitmapOf();
     while (csb != null && csb.getByteBuffer() != null) {
       for (Map.Entry<Long, byte[]> entry : expectedData.entrySet()) {

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/QuorumTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/QuorumTest.java
@@ -36,8 +36,8 @@ import org.apache.uniffle.client.factory.ShuffleServerClientFactory;
 import org.apache.uniffle.client.impl.ShuffleReadClientImpl;
 import org.apache.uniffle.client.impl.ShuffleWriteClientImpl;
 import org.apache.uniffle.client.impl.grpc.ShuffleServerGrpcClient;
-import org.apache.uniffle.client.response.CompressedShuffleBlock;
 import org.apache.uniffle.client.response.SendShuffleDataResult;
+import org.apache.uniffle.client.response.ShuffleBlock;
 import org.apache.uniffle.common.ClientType;
 import org.apache.uniffle.common.PartitionRange;
 import org.apache.uniffle.common.RemoteStorageInfo;
@@ -1032,7 +1032,7 @@ public class QuorumTest extends ShuffleReadWriteBase {
       ShuffleReadClientImpl readClient,
       Map<Long, byte[]> expectedData,
       Roaring64NavigableMap blockIdBitmap) {
-    CompressedShuffleBlock csb = readClient.readShuffleBlockData();
+    ShuffleBlock csb = readClient.readShuffleBlockData();
     Roaring64NavigableMap matched = Roaring64NavigableMap.bitmapOf();
     while (csb != null && csb.getByteBuffer() != null) {
       for (Map.Entry<Long, byte[]> entry : expectedData.entrySet()) {

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerWithHadoopTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerWithHadoopTest.java
@@ -42,8 +42,8 @@ import org.apache.uniffle.client.request.RssFinishShuffleRequest;
 import org.apache.uniffle.client.request.RssRegisterShuffleRequest;
 import org.apache.uniffle.client.request.RssSendCommitRequest;
 import org.apache.uniffle.client.request.RssSendShuffleDataRequest;
-import org.apache.uniffle.client.response.CompressedShuffleBlock;
 import org.apache.uniffle.client.response.RssSendShuffleDataResponse;
+import org.apache.uniffle.client.response.ShuffleBlock;
 import org.apache.uniffle.common.ClientType;
 import org.apache.uniffle.common.PartitionRange;
 import org.apache.uniffle.common.ShuffleBlockInfo;
@@ -247,7 +247,7 @@ public class ShuffleServerWithHadoopTest extends ShuffleReadWriteBase {
       ShuffleReadClientImpl readClient,
       Map<Long, byte[]> expectedData,
       Roaring64NavigableMap blockIdBitmap) {
-    CompressedShuffleBlock csb = readClient.readShuffleBlockData();
+    ShuffleBlock csb = readClient.readShuffleBlockData();
     Roaring64NavigableMap matched = Roaring64NavigableMap.bitmapOf();
     while (csb != null && csb.getByteBuffer() != null) {
       for (Entry<Long, byte[]> entry : expectedData.entrySet()) {

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerWithKerberizedHadoopTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerWithKerberizedHadoopTest.java
@@ -45,8 +45,8 @@ import org.apache.uniffle.client.request.RssFinishShuffleRequest;
 import org.apache.uniffle.client.request.RssRegisterShuffleRequest;
 import org.apache.uniffle.client.request.RssSendCommitRequest;
 import org.apache.uniffle.client.request.RssSendShuffleDataRequest;
-import org.apache.uniffle.client.response.CompressedShuffleBlock;
 import org.apache.uniffle.client.response.RssSendShuffleDataResponse;
+import org.apache.uniffle.client.response.ShuffleBlock;
 import org.apache.uniffle.common.ClientType;
 import org.apache.uniffle.common.KerberizedHadoopBase;
 import org.apache.uniffle.common.PartitionRange;
@@ -365,7 +365,7 @@ public class ShuffleServerWithKerberizedHadoopTest extends KerberizedHadoopBase 
       ShuffleReadClientImpl readClient,
       Map<Long, byte[]> expectedData,
       Roaring64NavigableMap blockIdBitmap) {
-    CompressedShuffleBlock csb = readClient.readShuffleBlockData();
+    ShuffleBlock csb = readClient.readShuffleBlockData();
     Roaring64NavigableMap matched = Roaring64NavigableMap.bitmapOf();
     while (csb != null && csb.getByteBuffer() != null) {
       for (Map.Entry<Long, byte[]> entry : expectedData.entrySet()) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is to introduce the overlapping decompression for the shuffle reading for the better shuffle speed.

### Why are the changes needed?

for #2601

When applying the https://github.com/apache/uniffle/pull/2598 into the benchmark of terasort 100g, I found some bottleneck for the decompression time in the read phase. 

Based on a 100 GB Terasort benchmark, the results are impressive, reducing shuffle read time by 50% after applying this PR.

<img width="1911" height="716" alt="image" src="https://github.com/user-attachments/assets/707598fb-0850-4d38-8453-f34f852fc6af" />


### Does this PR introduce _any_ user-facing change?

Yes

### How was this patch tested?

1. Unit tests.
