### PR TITLE
[#2614] improvement(client): Add test case for Incorrect header length for getLocalShuffleDataV3

### DIFF
--- a/common/src/main/java/org/apache/uniffle/common/netty/protocol/GetLocalShuffleDataV3Request.java
+++ b/common/src/main/java/org/apache/uniffle/common/netty/protocol/GetLocalShuffleDataV3Request.java
@@ -118,4 +118,12 @@ public class GetLocalShuffleDataV3Request extends GetLocalShuffleDataV2Request {
   public String getOperationType() {
     return "getLocalShuffleDataV3";
   }
+
+  public List<ReadSegment> getNextReadSegments() {
+    return nextReadSegments;
+  }
+
+  public long getTaskAttemptId() {
+    return taskAttemptId;
+  }
 }

--- a/common/src/test/java/org/apache/uniffle/common/netty/protocol/NettyProtocolTest.java
+++ b/common/src/test/java/org/apache/uniffle/common/netty/protocol/NettyProtocolTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Test;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
 
 import org.apache.uniffle.common.BufferSegment;
+import org.apache.uniffle.common.ReadSegment;
 import org.apache.uniffle.common.ShuffleBlockInfo;
 import org.apache.uniffle.common.ShufflePartitionedBlock;
 import org.apache.uniffle.common.ShuffleServerInfo;
@@ -164,6 +165,33 @@ public class NettyProtocolTest {
     assertEquals(getLocalShuffleDataRequest.getLength(), getLocalShuffleDataRequest1.getLength());
     assertEquals(
         getLocalShuffleDataRequest.getTimestamp(), getLocalShuffleDataRequest1.getTimestamp());
+  }
+
+  @Test
+  public void testGetLocalShuffleDataV3Request() {
+    List<ReadSegment> readSegments =
+        Lists.newArrayList(new ReadSegment(100, 100), new ReadSegment(200, 200));
+    GetLocalShuffleDataV3Request request =
+        new GetLocalShuffleDataV3Request(
+            1L,
+            "test_app",
+            1,
+            1,
+            1,
+            100,
+            0,
+            200,
+            1,
+            readSegments,
+            System.currentTimeMillis(),
+            123L);
+    int encodeLength = request.encodedLength();
+    ByteBuf byteBuf = Unpooled.buffer(encodeLength, encodeLength);
+    request.encode(byteBuf);
+    assertEquals(encodeLength, byteBuf.readableBytes());
+    GetLocalShuffleDataV3Request decodedRequest = GetLocalShuffleDataV3Request.decode(byteBuf);
+    assertTrue(NettyProtocolTestUtils.compareGetLocalShuffleDataV3Request(request, decodedRequest));
+    byteBuf.release();
   }
 
   @Test

--- a/common/src/test/java/org/apache/uniffle/common/netty/protocol/NettyProtocolTestUtils.java
+++ b/common/src/test/java/org/apache/uniffle/common/netty/protocol/NettyProtocolTestUtils.java
@@ -138,4 +138,26 @@ public class NettyProtocolTestUtils {
     }
     return comparePartitionToBlockListV1(req1.getPartitionToBlocks(), req2.getPartitionToBlocks());
   }
+
+  public static boolean compareGetLocalShuffleDataV3Request(
+      GetLocalShuffleDataV3Request req1, GetLocalShuffleDataV3Request req2) {
+    if (req1 == req2) {
+      return true;
+    }
+    if (req1 == null || req2 == null) {
+      return false;
+    }
+    return req1.getRequestId() == req2.getRequestId()
+        && req1.getAppId().equals(req2.getAppId())
+        && req1.getShuffleId() == req2.getShuffleId()
+        && req1.getPartitionId() == req2.getPartitionId()
+        && req1.getPartitionNumPerRange() == req2.getPartitionNumPerRange()
+        && req1.getPartitionNum() == req2.getPartitionNum()
+        && req1.getOffset() == req2.getOffset()
+        && req1.getLength() == req2.getLength()
+        && req1.getTimestamp() == req2.getTimestamp()
+        && req1.getStorageId() == req2.getStorageId()
+        && req1.getTaskAttemptId() == req2.getTaskAttemptId()
+        && req1.getNextReadSegments().equals(req2.getNextReadSegments());
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add test case for Incorrect header length for getLocalShuffleDataV3

### Why are the changes needed?
for https://github.com/apache/uniffle/issues/2614

### Does this PR introduce any user-facing change?
No.

### How was this patch tested?
UT