### PR TITLE
[#2618] fix(spark): Invalid reassign status show in spark UI tab

### DIFF
--- a/client-spark/common/src/main/java/org/apache/uniffle/shuffle/manager/RssShuffleManagerBase.java
+++ b/client-spark/common/src/main/java/org/apache/uniffle/shuffle/manager/RssShuffleManagerBase.java
@@ -1155,8 +1155,8 @@ public abstract class RssShuffleManagerBase implements RssShuffleManagerInterfac
   }
 
   /** This method will check the historical state to avoid posting duplicate events */
-  private void postReassignTriggeredEvent(AtomicBoolean tag) {
-    if (tag.compareAndSet(false, true)) {
+  private void postReassignTriggeredEvent(AtomicBoolean isReassign) {
+    if (isReassign.compareAndSet(false, true)) {
       TaskReassignInfoEvent reassignInfoEvent =
           new TaskReassignInfoEvent(
               reassignTriggeredOnPartitionSplit.get(),

--- a/client-spark/common/src/main/java/org/apache/uniffle/shuffle/manager/RssShuffleManagerBase.java
+++ b/client-spark/common/src/main/java/org/apache/uniffle/shuffle/manager/RssShuffleManagerBase.java
@@ -1024,7 +1024,7 @@ public abstract class RssShuffleManagerBase implements RssShuffleManagerInterfac
         "The stage retry has been triggered successfully for the shuffleId: {}, attemptNumber: {}",
         shuffleId,
         stageAttemptNumber);
-    this.reassignTriggeredOnStageRetry.set(true);
+    postReassignTriggeredEvent(reassignTriggeredOnStageRetry);
     return true;
   }
 
@@ -1148,12 +1148,21 @@ public abstract class RssShuffleManagerBase implements RssShuffleManagerInterfac
           System.currentTimeMillis() - startTime,
           partitionSplit,
           reassignResult);
-      if (partitionSplit) {
-        this.reassignTriggeredOnPartitionSplit.set(true);
-      } else {
-        this.reassignTriggeredOnBlockSendFailure.set(true);
-      }
+      postReassignTriggeredEvent(
+          partitionSplit ? reassignTriggeredOnPartitionSplit : reassignTriggeredOnBlockSendFailure);
       return internalHandle;
+    }
+  }
+
+  /** This method will check the historical state to avoid posting duplicate events */
+  private void postReassignTriggeredEvent(AtomicBoolean tag) {
+    if (tag.compareAndSet(false, true)) {
+      TaskReassignInfoEvent reassignInfoEvent =
+          new TaskReassignInfoEvent(
+              reassignTriggeredOnPartitionSplit.get(),
+              reassignTriggeredOnBlockSendFailure.get(),
+              reassignTriggeredOnStageRetry.get());
+      RssSparkShuffleUtils.getActiveSparkContext().listenerBus().post(reassignInfoEvent);
     }
   }
 
@@ -1195,16 +1204,6 @@ public abstract class RssShuffleManagerBase implements RssShuffleManagerInterfac
 
   @Override
   public void stop() {
-    if (this.isDriver && partitionReassignEnabled) {
-      // send reassign event into spark event store
-      TaskReassignInfoEvent reassignInfoEvent =
-          new TaskReassignInfoEvent(
-              reassignTriggeredOnPartitionSplit.get(),
-              reassignTriggeredOnBlockSendFailure.get(),
-              reassignTriggeredOnStageRetry.get());
-      RssSparkShuffleUtils.getActiveSparkContext().listenerBus().post(reassignInfoEvent);
-    }
-
     if (managerClientSupplier != null
         && managerClientSupplier instanceof ExpiringCloseableSupplier) {
       ((ExpiringCloseableSupplier<ShuffleManagerClient>) managerClientSupplier).close();

--- a/client-spark/extension/src/main/scala/org/apache/spark/ui/ShufflePage.scala
+++ b/client-spark/extension/src/main/scala/org/apache/spark/ui/ShufflePage.scala
@@ -334,9 +334,9 @@ class ShufflePage(parent: ShuffleTab) extends WebUIPage("") with Logging {
             </li>
             <li>
               <a>
-                <strong>Reassign Status(partitionSplit/blockSentFailure/stageRetry):</strong>
+                <strong>Reassign Status:</strong>
               </a>
-              {reassignInfo.isReassignTriggeredOnPartitionSplit} / {reassignInfo.isReassignTriggeredOnBlockSendFailure} / {reassignInfo.isReassignTriggeredOnStageRetry}
+              partitionSplit={reassignInfo.isReassignTriggeredOnPartitionSplit}, blockSentFailure={reassignInfo.isReassignTriggeredOnBlockSendFailure}, stageRetry={reassignInfo.isReassignTriggeredOnStageRetry}
             </li>
           </ul>
         </div>

--- a/client-spark/extension/src/main/scala/org/apache/spark/ui/ShufflePage.scala
+++ b/client-spark/extension/src/main/scala/org/apache/spark/ui/ShufflePage.scala
@@ -334,21 +334,9 @@ class ShufflePage(parent: ShuffleTab) extends WebUIPage("") with Logging {
             </li>
             <li>
               <a>
-                <strong>ReassignTriggeredOnPartitionSplit: </strong>
+                <strong>Reassign Status(partitionSplit/blockSentFailure/stageRetry):</strong>
               </a>
-              {reassignInfo.isReassignTriggeredOnPartitionSplit}
-            </li>
-            <li>
-              <a>
-                <strong>ReassignTriggeredOnBlockSendFailure: </strong>
-              </a>
-              {reassignInfo.isReassignTriggeredOnBlockSendFailure}
-            </li>
-            <li>
-              <a>
-                <strong>ReassignTriggeredOnStageRetry: </strong>
-              </a>
-              {reassignInfo.isReassignTriggeredOnStageRetry}
+              {reassignInfo.isReassignTriggeredOnPartitionSplit} / {reassignInfo.isReassignTriggeredOnBlockSendFailure} / {reassignInfo.isReassignTriggeredOnStageRetry}
             </li>
           </ul>
         </div>


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix the invalid reassign status show in spark UI tab

### Why are the changes needed?

In the original design, the reassign info event is sent in the final stop method. However, because the post operation runs asynchronously, the listener may not receive the event before the JVM shuts down, so the event is effectively dropped.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Internal spark job test
