### PR TITLE
[#2622] fix(spark): Make shuffleServerInfo comparable for `updatePartitionSplitAssignment`

### DIFF
--- a/client-spark/common/src/test/java/org/apache/spark/shuffle/writer/TaskAttemptAssignmentTest.java
+++ b/client-spark/common/src/test/java/org/apache/spark/shuffle/writer/TaskAttemptAssignmentTest.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.shuffle.writer;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.spark.shuffle.handle.ShuffleHandleInfo;
+import org.apache.spark.shuffle.handle.split.PartitionSplitInfo;
+import org.junit.jupiter.api.Test;
+
+import org.apache.uniffle.client.PartitionDataReplicaRequirementTracking;
+import org.apache.uniffle.common.PartitionSplitMode;
+import org.apache.uniffle.common.RemoteStorageInfo;
+import org.apache.uniffle.common.ShuffleServerInfo;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TaskAttemptAssignmentTest {
+
+  class MockShuffleHandleInfo implements ShuffleHandleInfo {
+
+    @Override
+    public Set<ShuffleServerInfo> getServers() {
+      return Collections.emptySet();
+    }
+
+    @Override
+    public Map<Integer, List<ShuffleServerInfo>> getAvailablePartitionServersForWriter(
+        Map<Integer, List<ShuffleServerInfo>> exclusivePartitionServers) {
+      return Collections.emptyMap();
+    }
+
+    @Override
+    public Map<Integer, List<ShuffleServerInfo>> getAllPartitionServersForReader() {
+      return Collections.emptyMap();
+    }
+
+    @Override
+    public PartitionDataReplicaRequirementTracking createPartitionReplicaTracking() {
+      return null;
+    }
+
+    @Override
+    public int getShuffleId() {
+      return 0;
+    }
+
+    @Override
+    public RemoteStorageInfo getRemoteStorage() {
+      return null;
+    }
+
+    @Override
+    public PartitionSplitInfo getPartitionSplitInfo(int partitionId) {
+      return new PartitionSplitInfo(1, true, PartitionSplitMode.LOAD_BALANCE, null);
+    }
+  }
+
+  @Test
+  public void testUpdatePartitionSplitAssignment() {
+    TaskAttemptAssignment assignment = new TaskAttemptAssignment(1, new MockShuffleHandleInfo());
+    assertTrue(
+        assignment.updatePartitionSplitAssignment(
+            1, Arrays.asList(new ShuffleServerInfo("localhost", 122))));
+  }
+}

--- a/common/src/main/java/org/apache/uniffle/common/ShuffleServerInfo.java
+++ b/common/src/main/java/org/apache/uniffle/common/ShuffleServerInfo.java
@@ -27,7 +27,7 @@ import org.slf4j.LoggerFactory;
 
 import org.apache.uniffle.proto.RssProtos;
 
-public class ShuffleServerInfo implements Serializable {
+public class ShuffleServerInfo implements Serializable, Comparable<ShuffleServerInfo> {
   private static final Logger LOGGER = LoggerFactory.getLogger(ShuffleServerInfo.class);
   private static final String DELIMITER = "-";
   private static final long serialVersionUID = 0L;
@@ -169,5 +169,10 @@ public class ShuffleServerInfo implements Serializable {
     }
     LOGGER.warn("Server id is invalid. {}", serverId);
     return null;
+  }
+
+  @Override
+  public int compareTo(ShuffleServerInfo o) {
+    return this.id.compareTo(o.id);
   }
 }

--- a/common/src/test/java/org/apache/uniffle/common/ShuffleServerInfoTest.java
+++ b/common/src/test/java/org/apache/uniffle/common/ShuffleServerInfoTest.java
@@ -26,6 +26,16 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 public class ShuffleServerInfoTest {
 
   @Test
+  public void testCompareTo() {
+    ShuffleServerInfo info1 = new ShuffleServerInfo("localhost", 1234);
+    ShuffleServerInfo info2 = new ShuffleServerInfo("localhost", 1235);
+    ShuffleServerInfo info3 = new ShuffleServerInfo("localhost", 1235);
+    assertEquals(-1, info1.compareTo(info2));
+    assertEquals(1, info2.compareTo(info1));
+    assertEquals(0, info2.compareTo(info3));
+  }
+
+  @Test
   public void testEquals() {
     ShuffleServerInfo info = new ShuffleServerInfo("1", "localhost", 1234);
     ShuffleServerInfo info2 = new ShuffleServerInfo("1", "localhost", 1234);


### PR DESCRIPTION
### What changes were proposed in this pull request?

Make shuffleServerInfo comparable for `updatePartitionSplitAssignment`

### Why are the changes needed?

fix 2622

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Unit tests
