### PR TITLE
fix: Remove incubator to correct uniffle svn url

### DIFF
--- a/release/publish_to_svn.sh
+++ b/release/publish_to_svn.sh
@@ -39,7 +39,7 @@ fi
 
 RELEASE_TAG="${RELEASE_VERSION}-rc${RELEASE_RC_NO}"
 
-SVN_STAGING_REPO="https://dist.apache.org/repos/dist/dev/incubator/uniffle"
+SVN_STAGING_REPO="https://dist.apache.org/repos/dist/dev/uniffle"
 
 RELEASE_DIR="${PROJECT_DIR}/tmp"
 SVN_STAGING_DIR="${PROJECT_DIR}/tmp/dev/uniffle"


### PR DESCRIPTION

### What changes were proposed in this pull request?

Remove incubator to correct uniffle svn url

### Why are the changes needed?

fix invalid url

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Neen't
