### PR TITLE
[#2592] fix(spark): Skip failure when reporting shuffle write metrics to driver

### DIFF
--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
@@ -969,19 +969,25 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
                   bufferManager.getSortTime(),
                   bufferManager.getRequireMemoryTime(),
                   checkSendResultMills);
-          RssReportShuffleWriteMetricResponse response =
-              shuffleManagerClient.reportShuffleWriteMetric(
-                  new RssReportShuffleWriteMetricRequest(
-                      taskContext.stageId(),
-                      shuffleId,
-                      taskContext.taskAttemptId(),
-                      bufferManager.getShuffleServerPushCostTracker().toMetric(),
-                      writeTimes,
-                      isShuffleWriteFailed,
-                      shuffleWriteFailureReason,
-                      bufferManager.getUncompressedDataLen()));
-          if (response.getStatusCode() != StatusCode.SUCCESS) {
-            LOG.error("Errors on reporting shuffle write metrics to driver");
+          try {
+            RssReportShuffleWriteMetricResponse response =
+                shuffleManagerClient.reportShuffleWriteMetric(
+                    new RssReportShuffleWriteMetricRequest(
+                        taskContext.stageId(),
+                        shuffleId,
+                        taskContext.taskAttemptId(),
+                        bufferManager.getShuffleServerPushCostTracker().toMetric(),
+                        writeTimes,
+                        isShuffleWriteFailed,
+                        shuffleWriteFailureReason,
+                        bufferManager.getUncompressedDataLen()));
+            if (response.getStatusCode() != StatusCode.SUCCESS) {
+              LOG.error(
+                  "Errors on reporting shuffle write metrics to driver. status_code: {}",
+                  response.getStatusCode());
+            }
+          } catch (Exception e) {
+            LOG.error("Errors on reporting shuffle write metrics to driver", e);
           }
         }
       }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Skip failure when reporting shuffle write metrics to driver

### Why are the changes needed?

followup the PR for the #2592 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Needn't
