### PR TITLE
[#2631] fix(server): Potential data loss due to the shuffle result report retry

### DIFF
--- a/server/src/main/java/org/apache/uniffle/server/ShuffleTaskManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleTaskManager.java
@@ -908,10 +908,9 @@ public class ShuffleTaskManager {
 
       ShuffleBlockIdManager manager = shuffleTaskInfo.getShuffleBlockIdManager();
       if (manager != null) {
-        manager.removeBlockIdByAppId(appId);
+        manager.remove(appId);
       }
-      shuffleBlockIdManager.removeBlockIdByAppId(appId);
-      shuffleBlockIdManager.removeBitmapLocks(appId);
+      shuffleBlockIdManager.remove(appId);
       shuffleBufferManager.removeBuffer(appId);
       shuffleFlushManager.removeResources(appId);
 

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleTaskManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleTaskManager.java
@@ -911,6 +911,7 @@ public class ShuffleTaskManager {
         manager.removeBlockIdByAppId(appId);
       }
       shuffleBlockIdManager.removeBlockIdByAppId(appId);
+      shuffleBlockIdManager.removeBitmapLocks(appId);
       shuffleBufferManager.removeBuffer(appId);
       shuffleFlushManager.removeResources(appId);
 

--- a/server/src/main/java/org/apache/uniffle/server/block/DefaultShuffleBlockIdManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/block/DefaultShuffleBlockIdManager.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
@@ -212,12 +211,8 @@ public class DefaultShuffleBlockIdManager implements ShuffleBlockIdManager {
   }
 
   @Override
-  public void removeBlockIdByAppId(String appId) {
+  public void remove(String appId) {
     partitionsToBlockIds.remove(appId);
-  }
-
-  @Override
-  public void removeBitmapLocks(String appId) {
     bitmapLocks.remove(appId);
   }
 
@@ -255,7 +250,7 @@ public class DefaultShuffleBlockIdManager implements ShuffleBlockIdManager {
 
   private ReadWriteLock getLockForBitmap(String appId, int shuffleId, int bitmapArrLocation) {
     Map<String, ReadWriteLock> innerMap =
-        bitmapLocks.computeIfAbsent(appId, k -> new ConcurrentHashMap<>());
+        bitmapLocks.computeIfAbsent(appId, k -> JavaUtils.newConcurrentMap());
     String key = shuffleId + "_" + bitmapArrLocation;
     return innerMap.computeIfAbsent(key, k -> new ReentrantReadWriteLock());
   }

--- a/server/src/main/java/org/apache/uniffle/server/block/PartitionedShuffleBlockIdManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/block/PartitionedShuffleBlockIdManager.java
@@ -138,12 +138,8 @@ public class PartitionedShuffleBlockIdManager implements ShuffleBlockIdManager {
   }
 
   @Override
-  public void removeBlockIdByAppId(String appId) {
+  public void remove(String appId) {
     partitionsToBlockIds.remove(appId);
-  }
-
-  @Override
-  public void removeBitmapLocks(String appId) {
     bitmapLocks.remove(appId);
   }
 
@@ -190,7 +186,7 @@ public class PartitionedShuffleBlockIdManager implements ShuffleBlockIdManager {
 
   private ReadWriteLock getLockForBitmap(String appId, int shuffleId, int partititionId) {
     Map<String, ReadWriteLock> innerMap =
-        bitmapLocks.computeIfAbsent(appId, k -> new ConcurrentHashMap<>());
+        bitmapLocks.computeIfAbsent(appId, k -> JavaUtils.newConcurrentMap());
     String key = shuffleId + "_" + partititionId;
     return innerMap.computeIfAbsent(key, k -> new ReentrantReadWriteLock());
   }

--- a/server/src/main/java/org/apache/uniffle/server/block/ShuffleBlockIdManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/block/ShuffleBlockIdManager.java
@@ -48,6 +48,8 @@ public interface ShuffleBlockIdManager {
 
   void removeBlockIdByAppId(String appId);
 
+  void removeBitmapLocks(String appId);
+
   long getTotalBlockCount();
 
   long getBlockCountByShuffleId(String appId, List<Integer> shuffleIds);

--- a/server/src/main/java/org/apache/uniffle/server/block/ShuffleBlockIdManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/block/ShuffleBlockIdManager.java
@@ -46,9 +46,12 @@ public interface ShuffleBlockIdManager {
 
   void removeBlockIdByShuffleId(String appId, List<Integer> shuffleIds);
 
-  void removeBlockIdByAppId(String appId);
-
-  void removeBitmapLocks(String appId);
+  /**
+   * Clear the objects during the operation of the APP.
+   *
+   * @param appId
+   */
+  void remove(String appId);
 
   long getTotalBlockCount();
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Solve the problem of data loss caused by Spark task retries and Block metadata Report retries.

### Why are the changes needed?

Fix: #2631 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Exist UT.
