### PR TITLE
[#2630] improvement(client): Add decompressed data length check for LZ4 

### DIFF
--- a/common/src/main/java/org/apache/uniffle/common/compression/Lz4Codec.java
+++ b/common/src/main/java/org/apache/uniffle/common/compression/Lz4Codec.java
@@ -41,9 +41,17 @@ public class Lz4Codec extends Codec {
 
   @Override
   public void decompress(ByteBuffer src, int uncompressedLen, ByteBuffer dest, int destOffset) {
-    lz4Factory
-        .fastDecompressor()
-        .decompress(src, src.position(), dest, destOffset, uncompressedLen);
+    int realDecompressed =
+        lz4Factory
+            .fastDecompressor()
+            .decompress(src, src.position(), dest, destOffset, uncompressedLen);
+    if (realDecompressed != uncompressedLen) {
+      throw new RssException(
+          "Decompress failed due to unexcepted decompress length. (real/expected): "
+              + realDecompressed
+              + "/"
+              + uncompressedLen);
+    }
   }
 
   @Override


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add the decompressed data length check for LZ4 

### Why are the changes needed?

To solve and inspect the #2630 , this PR introduces the data length check mechanism to throw exception when inconsistency happens

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests
