### PR TITLE
[#2769] improvement(ci): clean build outputs between sequential Maven profiles

### DIFF
--- a/.github/workflows/sequential.yml
+++ b/.github/workflows/sequential.yml
@@ -70,29 +70,29 @@ jobs:
           mvn-${{ inputs.java-version }}-${{ inputs.cache-key }}-
     - name: Execute `./mvnw ${{ inputs.maven-args }} -Pspark4`
       if: inputs.java-version == '17'
-      run: ./mvnw -B -fae ${{ inputs.maven-args }} -Pspark4 | tee -a /tmp/maven.log;
+      run: ./mvnw -B -fae clean ${{ inputs.maven-args }} -Pspark4 | tee -a /tmp/maven.log;
       shell: bash
     - name: Execute `./mvnw ${{ inputs.maven-args }} -Pspark4.1`
       if: inputs.java-version == '17'
-      run: ./mvnw -B -fae ${{ inputs.maven-args }} -Pspark4.1 | tee -a /tmp/maven.log;
+      run: ./mvnw -B -fae clean ${{ inputs.maven-args }} -Pspark4.1 | tee -a /tmp/maven.log;
       shell: bash
     - name: Execute `./mvnw ${{ inputs.maven-args }} -Pspark3`
-      run: ./mvnw -B -fae ${{ inputs.maven-args }} -Pspark3 | tee -a /tmp/maven.log;
+      run: ./mvnw -B -fae clean ${{ inputs.maven-args }} -Pspark3 | tee -a /tmp/maven.log;
       shell: bash
     - name: Execute `./mvnw ${{ inputs.maven-args }} -Pspark2`
-      run: ./mvnw -B -fae ${{ inputs.maven-args }} -Pspark2 | tee -a /tmp/maven.log;
+      run: ./mvnw -B -fae clean ${{ inputs.maven-args }} -Pspark2 | tee -a /tmp/maven.log;
       shell: bash
     - name: Execute `./mvnw ${{ inputs.maven-args }} -Pmr,hadoop2.8`
-      run: ./mvnw -B -fae ${{ inputs.maven-args }} -Pmr,hadoop2.8 | tee -a /tmp/maven.log;
+      run: ./mvnw -B -fae clean ${{ inputs.maven-args }} -Pmr,hadoop2.8 | tee -a /tmp/maven.log;
       shell: bash
     - name: Execute `./mvnw ${{ inputs.maven-args }} -Pmr,hadoop3.2`
-      run: ./mvnw -B -fae ${{ inputs.maven-args }} -Pmr,hadoop3.2 | tee -a /tmp/maven.log;
+      run: ./mvnw -B -fae clean ${{ inputs.maven-args }} -Pmr,hadoop3.2 | tee -a /tmp/maven.log;
       shell: bash
     - name: Execute `./mvnw ${{ inputs.maven-args }} -Ptez`
-      run: ./mvnw -B -fae ${{ inputs.maven-args }} -Ptez | tee -a /tmp/maven.log;
+      run: ./mvnw -B -fae clean ${{ inputs.maven-args }} -Ptez | tee -a /tmp/maven.log;
       shell: bash
     - name: Execute `./mvnw ${{ inputs.maven-args }} -Pdashboard`
-      run: ./mvnw -B -fae ${{ inputs.maven-args }} -Pdashboard | tee -a /tmp/maven.log;
+      run: ./mvnw -B -fae clean ${{ inputs.maven-args }} -Pdashboard | tee -a /tmp/maven.log;
       shell: bash
     - name: Summary of failures
       if: ${{ failure() && inputs.summary != '' }}

--- a/.github/workflows/sequential.yml
+++ b/.github/workflows/sequential.yml
@@ -70,33 +70,33 @@ jobs:
           mvn-${{ inputs.java-version }}-${{ inputs.cache-key }}-
     - name: Execute `./mvnw ${{ inputs.maven-args }} -Pspark4`
       if: inputs.java-version == '17'
-      run: ./mvnw -B -fae ${{ inputs.maven-args }} -Pspark4 | tee -a /tmp/maven.log;
+      run: ./mvnw -B -fae clean ${{ inputs.maven-args }} -Pspark4 | tee -a /tmp/maven.log;
       shell: bash
     - name: Execute `./mvnw ${{ inputs.maven-args }} -Pspark4.1`
       if: inputs.java-version == '17'
-      run: ./mvnw -B -fae ${{ inputs.maven-args }} -Pspark4.1 | tee -a /tmp/maven.log;
+      run: ./mvnw -B -fae clean ${{ inputs.maven-args }} -Pspark4.1 | tee -a /tmp/maven.log;
       shell: bash
     - name: Execute `./mvnw ${{ inputs.maven-args }} -Pspark4.2`
       if: inputs.java-version == '17'
       run: ./mvnw -B -fae ${{ inputs.maven-args }} -Pspark4.2 | tee -a /tmp/maven.log;
       shell: bash
     - name: Execute `./mvnw ${{ inputs.maven-args }} -Pspark3`
-      run: ./mvnw -B -fae ${{ inputs.maven-args }} -Pspark3 | tee -a /tmp/maven.log;
+      run: ./mvnw -B -fae clean ${{ inputs.maven-args }} -Pspark3 | tee -a /tmp/maven.log;
       shell: bash
     - name: Execute `./mvnw ${{ inputs.maven-args }} -Pspark2`
-      run: ./mvnw -B -fae ${{ inputs.maven-args }} -Pspark2 | tee -a /tmp/maven.log;
+      run: ./mvnw -B -fae clean ${{ inputs.maven-args }} -Pspark2 | tee -a /tmp/maven.log;
       shell: bash
     - name: Execute `./mvnw ${{ inputs.maven-args }} -Pmr,hadoop2.8`
-      run: ./mvnw -B -fae ${{ inputs.maven-args }} -Pmr,hadoop2.8 | tee -a /tmp/maven.log;
+      run: ./mvnw -B -fae clean ${{ inputs.maven-args }} -Pmr,hadoop2.8 | tee -a /tmp/maven.log;
       shell: bash
     - name: Execute `./mvnw ${{ inputs.maven-args }} -Pmr,hadoop3.2`
-      run: ./mvnw -B -fae ${{ inputs.maven-args }} -Pmr,hadoop3.2 | tee -a /tmp/maven.log;
+      run: ./mvnw -B -fae clean ${{ inputs.maven-args }} -Pmr,hadoop3.2 | tee -a /tmp/maven.log;
       shell: bash
     - name: Execute `./mvnw ${{ inputs.maven-args }} -Ptez`
-      run: ./mvnw -B -fae ${{ inputs.maven-args }} -Ptez | tee -a /tmp/maven.log;
+      run: ./mvnw -B -fae clean ${{ inputs.maven-args }} -Ptez | tee -a /tmp/maven.log;
       shell: bash
     - name: Execute `./mvnw ${{ inputs.maven-args }} -Pdashboard`
-      run: ./mvnw -B -fae ${{ inputs.maven-args }} -Pdashboard | tee -a /tmp/maven.log;
+      run: ./mvnw -B -fae clean ${{ inputs.maven-args }} -Pdashboard | tee -a /tmp/maven.log;
       shell: bash
     - name: Summary of failures
       if: ${{ failure() && inputs.summary != '' }}

--- a/.github/workflows/sequential.yml
+++ b/.github/workflows/sequential.yml
@@ -78,7 +78,7 @@ jobs:
       shell: bash
     - name: Execute `./mvnw ${{ inputs.maven-args }} -Pspark4.2`
       if: inputs.java-version == '17'
-      run: ./mvnw -B -fae ${{ inputs.maven-args }} -Pspark4.2 | tee -a /tmp/maven.log;
+      run: ./mvnw -B -fae clean ${{ inputs.maven-args }} -Pspark4.2 | tee -a /tmp/maven.log;
       shell: bash
     - name: Execute `./mvnw ${{ inputs.maven-args }} -Pspark3`
       run: ./mvnw -B -fae clean ${{ inputs.maven-args }} -Pspark3 | tee -a /tmp/maven.log;


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add the Maven `clean` goal to every profile-specific invocation in
`.github/workflows/sequential.yml`, including:

- Spark 4, 4.1, 3, and 2
- Hadoop MR 2.8 and 3.2
- Tez
- Dashboard

### Why are the changes needed?

The sequential workflow runs multiple incompatible Maven profiles in the same
workspace. Reusing existing `target` directories can cause Maven or
`scala-maven-plugin` incremental compilation to treat stale classes as
up-to-date.

Cleaning before each invocation ensures that every profile compiles and
packages only its selected sources and dependencies, making the workflow
independent of execution order.

Closes #2769.

### How was this patch tested?

existing CI

----
Generated by Codex (GPT-5.6)