### PR TITLE
fix(spark): Fix shuffle cleanup failure with RssShuffleManager on Spark 4

### DIFF
--- a/client-spark/spark4/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark4/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -43,6 +43,8 @@ import org.apache.spark.TaskContext;
 import org.apache.spark.broadcast.Broadcast;
 import org.apache.spark.executor.ShuffleReadMetrics;
 import org.apache.spark.executor.ShuffleWriteMetrics;
+import org.apache.spark.network.buffer.ManagedBuffer;
+import org.apache.spark.network.shuffle.MergedBlockMeta;
 import org.apache.spark.rdd.DeterministicLevel;
 import org.apache.spark.shuffle.events.ShuffleAssignmentInfoEvent;
 import org.apache.spark.shuffle.handle.MutableShuffleHandleInfo;
@@ -55,6 +57,7 @@ import org.apache.spark.shuffle.writer.RssShuffleWriter;
 import org.apache.spark.sql.internal.SQLConf;
 import org.apache.spark.storage.BlockId;
 import org.apache.spark.storage.BlockManagerId;
+import org.apache.spark.storage.ShuffleMergedBlockId;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -80,6 +83,36 @@ import org.apache.uniffle.shuffle.manager.RssShuffleManagerBase;
 
 public class RssShuffleManager extends RssShuffleManagerBase {
   private static final Logger LOG = LoggerFactory.getLogger(RssShuffleManager.class);
+  // RSS has no local shuffle files. Spark 4 calls this resolver while cleaning shuffle data from
+  // an external shuffle service, so return no blocks instead of failing the cleanup.
+  private static final ShuffleBlockResolver SHUFFLE_BLOCK_RESOLVER =
+      new ShuffleBlockResolver() {
+        @Override
+        public ManagedBuffer getBlockData(BlockId blockId, scala.Option<String[]> dirs) {
+          throw new RssException("RssShuffleManager does not store shuffle blocks locally");
+        }
+
+        @Override
+        public scala.collection.immutable.Seq<BlockId> getBlocksForShuffle(
+            int shuffleId, long mapId) {
+          return scala.collection.immutable.List$.MODULE$.empty();
+        }
+
+        @Override
+        public scala.collection.immutable.Seq<ManagedBuffer> getMergedBlockData(
+            ShuffleMergedBlockId blockId, scala.Option<String[]> dirs) {
+          throw new RssException("RssShuffleManager does not store merged shuffle blocks locally");
+        }
+
+        @Override
+        public MergedBlockMeta getMergedBlockMeta(
+            ShuffleMergedBlockId blockId, scala.Option<String[]> dirs) {
+          throw new RssException("RssShuffleManager does not store merged shuffle blocks locally");
+        }
+
+        @Override
+        public void stop() {}
+      };
 
   public RssShuffleManager(SparkConf conf, boolean isDriver) {
     super(conf, isDriver);
@@ -525,7 +558,7 @@ public class RssShuffleManager extends RssShuffleManagerBase {
 
   @Override
   public ShuffleBlockResolver shuffleBlockResolver() {
-    throw new RssException("RssShuffleManager.shuffleBlockResolver is not implemented");
+    return SHUFFLE_BLOCK_RESOLVER;
   }
 
   @Override

--- a/client-spark/spark4/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark4/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -83,36 +83,6 @@ import org.apache.uniffle.shuffle.manager.RssShuffleManagerBase;
 
 public class RssShuffleManager extends RssShuffleManagerBase {
   private static final Logger LOG = LoggerFactory.getLogger(RssShuffleManager.class);
-  // RSS has no local shuffle files. Spark 4 calls this resolver while cleaning shuffle data from
-  // an external shuffle service, so return no blocks instead of failing the cleanup.
-  private static final ShuffleBlockResolver SHUFFLE_BLOCK_RESOLVER =
-      new ShuffleBlockResolver() {
-        @Override
-        public ManagedBuffer getBlockData(BlockId blockId, scala.Option<String[]> dirs) {
-          throw new RssException("RssShuffleManager does not store shuffle blocks locally");
-        }
-
-        @Override
-        public scala.collection.immutable.Seq<BlockId> getBlocksForShuffle(
-            int shuffleId, long mapId) {
-          return scala.collection.immutable.List$.MODULE$.empty();
-        }
-
-        @Override
-        public scala.collection.immutable.Seq<ManagedBuffer> getMergedBlockData(
-            ShuffleMergedBlockId blockId, scala.Option<String[]> dirs) {
-          throw new RssException("RssShuffleManager does not store merged shuffle blocks locally");
-        }
-
-        @Override
-        public MergedBlockMeta getMergedBlockMeta(
-            ShuffleMergedBlockId blockId, scala.Option<String[]> dirs) {
-          throw new RssException("RssShuffleManager does not store merged shuffle blocks locally");
-        }
-
-        @Override
-        public void stop() {}
-      };
 
   public RssShuffleManager(SparkConf conf, boolean isDriver) {
     super(conf, isDriver);
@@ -555,6 +525,37 @@ public class RssShuffleManager extends RssShuffleManagerBase {
     }
     return Pair.of(taskIdBitmap, expectedRecordsRead);
   }
+
+  // RSS has no local shuffle files. Spark 4 calls this resolver while cleaning shuffle data from
+  // an external shuffle service, so return no blocks instead of failing the cleanup.
+  private static final ShuffleBlockResolver SHUFFLE_BLOCK_RESOLVER =
+      new ShuffleBlockResolver() {
+        @Override
+        public ManagedBuffer getBlockData(BlockId blockId, scala.Option<String[]> dirs) {
+          throw new RssException("RssShuffleManager does not store shuffle blocks locally");
+        }
+
+        @Override
+        public scala.collection.immutable.Seq<BlockId> getBlocksForShuffle(
+            int shuffleId, long mapId) {
+          return scala.collection.immutable.List$.MODULE$.empty();
+        }
+
+        @Override
+        public scala.collection.immutable.Seq<ManagedBuffer> getMergedBlockData(
+            ShuffleMergedBlockId blockId, scala.Option<String[]> dirs) {
+          throw new RssException("RssShuffleManager does not store merged shuffle blocks locally");
+        }
+
+        @Override
+        public MergedBlockMeta getMergedBlockMeta(
+            ShuffleMergedBlockId blockId, scala.Option<String[]> dirs) {
+          throw new RssException("RssShuffleManager does not store merged shuffle blocks locally");
+        }
+
+        @Override
+        public void stop() {}
+      };
 
   @Override
   public ShuffleBlockResolver shuffleBlockResolver() {

--- a/client-spark/spark4/src/test/java/org/apache/spark/shuffle/RssShuffleManagerTest.java
+++ b/client-spark/spark4/src/test/java/org/apache/spark/shuffle/RssShuffleManagerTest.java
@@ -22,12 +22,15 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
 
+import scala.Option;
+
 import org.apache.spark.Partitioner;
 import org.apache.spark.ShuffleDependency;
 import org.apache.spark.SparkConf;
 import org.apache.spark.shuffle.handle.ShuffleHandleInfo;
 import org.apache.spark.shuffle.handle.SimpleShuffleHandleInfo;
 import org.apache.spark.sql.internal.SQLConf;
+import org.apache.spark.storage.ShuffleBlockId;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -175,6 +178,9 @@ public class RssShuffleManagerTest extends RssShuffleManagerTestBase {
     ShuffleBlockResolver blockResolver = shuffleManager.shuffleBlockResolver();
 
     assertTrue(blockResolver.getBlocksForShuffle(1, 1L).isEmpty());
+    assertThrowsExactly(
+        RssException.class,
+        () -> blockResolver.getBlockData(new ShuffleBlockId(0, 0L, 0), Option.empty()));
   }
 
   @ParameterizedTest

--- a/client-spark/spark4/src/test/java/org/apache/spark/shuffle/RssShuffleManagerTest.java
+++ b/client-spark/spark4/src/test/java/org/apache/spark/shuffle/RssShuffleManagerTest.java
@@ -161,6 +161,22 @@ public class RssShuffleManagerTest extends RssShuffleManagerTestBase {
     assertNull(shuffleManager.getAppId());
   }
 
+  @Test
+  public void testShuffleBlockResolver() {
+    setupMockedRssShuffleUtils(StatusCode.SUCCESS);
+
+    SparkConf conf = new SparkConf();
+    conf.set(RssSparkConfig.RSS_DYNAMIC_CLIENT_CONF_ENABLED.key(), "false");
+    conf.set(RssSparkConfig.RSS_COORDINATOR_QUORUM.key(), "m1:8001,m2:8002");
+    conf.set("spark.rss.storage.type", StorageType.LOCALFILE.name());
+    conf.set(RssSparkConfig.RSS_TEST_MODE_ENABLE, true);
+
+    RssShuffleManager shuffleManager = new RssShuffleManager(conf, true);
+    ShuffleBlockResolver blockResolver = shuffleManager.shuffleBlockResolver();
+
+    assertTrue(blockResolver.getBlocksForShuffle(1, 1L).isEmpty());
+  }
+
   @ParameterizedTest
   @ValueSource(ints = {16, 20, 24})
   public void testRssShuffleManagerRegisterShuffle(int partitionIdBits) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add a `ShuffleBlockResolver` implementation for the Spark 4 `RssShuffleManager`.

Because RSS does not store shuffle blocks on local disks, the resolver:

- Returns an empty block sequence from `getBlocksForShuffle`.
- Reports a clear error if local or merged block data is requested.
- Uses a no-op `stop` implementation.

`RssShuffleManager.shuffleBlockResolver()` now returns this resolver instead of throwing an unsupported-operation exception.

### Why are the changes needed?

Spark 4 enables `spark.shuffle.service.removeShuffle` by default. During shuffle cleanup, Spark calls `shuffleBlockResolver().getBlocksForShuffle()` to locate blocks managed by the external shuffle service.

The previous RSS implementation threw an exception whenever `shuffleBlockResolver()` was called, causing `ContextCleaner` to report shuffle cleanup failures.

Returning an empty block sequence is appropriate because RSS stores shuffle data remotely and has no local shuffle blocks for Spark to remove.

Fix: #2777

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Tested manually, and no exceptions were observed.