### PR TITLE
chore: use Java 17 for style checks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,18 +40,21 @@ jobs:
     with:
       maven-args: spotless:check
       cache-key: spotless
+      java-version: '17'
 
   checkstyle:
     uses: ./.github/workflows/sequential.yml
     with:
       maven-args: checkstyle:check
       cache-key: checkstyle
+      java-version: '17'
 
   license:
     uses: ./.github/workflows/sequential.yml
     with:
       maven-args: apache-rat:check
       cache-key: license
+      java-version: '17'
       summary: "grep -r '!?????' --include='rat.txt' | awk '{print $3}'"
 
   spotbugs:
@@ -60,6 +63,7 @@ jobs:
     with:
       maven-args: test-compile spotbugs:check
       cache-key: spotbugs
+      java-version: '17'
 
   java-11:
     needs: [spotbugs] # delay execution

--- a/client-spark/spark4/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark4/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -102,7 +102,8 @@ public class RssShuffleManager extends RssShuffleManagerBase {
     super(conf, isDriver, dataPusher, taskToSuccessBlockIds, taskToFailedBlockSendTracker);
   }
 
-  // Called on the driver to assign shuffle servers via the coordinator and broadcast the handle to executors.
+  // Called on the driver to assign shuffle servers via the coordinator and broadcast the handle to
+  // executors.
   @Override
   public <K, V, C> ShuffleHandle registerShuffle(
       int shuffleId, ShuffleDependency<K, V, C> dependency) {
@@ -458,7 +459,8 @@ public class RssShuffleManager extends RssShuffleManagerBase {
     Iterator<Tuple2<BlockManagerId, Seq<Tuple3<BlockId, Object, Object>>>> mapStatusIter =
         SparkEnv.get()
             .mapOutputTracker()
-            .getMapSizesByExecutorId(shuffleId, startMapIndex, endMapIndex, startPartition, endPartition);
+            .getMapSizesByExecutorId(
+                shuffleId, startMapIndex, endMapIndex, startPartition, endPartition);
     final Iterator<Tuple2<BlockManagerId, Seq<Tuple3<BlockId, Object, Object>>>> immutableIter =
         mapStatusIter;
     Iterator<BlockManagerId> iter =

--- a/client-spark/spark4/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
+++ b/client-spark/spark4/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
@@ -468,7 +468,8 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
     }
   }
 
-  // Required by ShuffleWriter interface; returns empty since RSS does not support push-based shuffle.
+  // Required by ShuffleWriter interface; returns empty since RSS does not support push-based
+  // shuffle.
   public long[] getPartitionLengths() {
     return new long[0];
   }
@@ -710,7 +711,8 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
 
         shuffleTaskStats.check();
 
-        // TODO: Use preferred shuffle server host/port instead of dummy values to optimize read locality
+        // TODO: Use preferred shuffle server host/port instead of dummy values to optimize read
+        // locality
         final BlockManagerId blockManagerId =
             BlockManagerId.apply(
                 appId + "_" + taskId,

--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -26,4 +26,9 @@
     <Bug pattern="NM_METHOD_NAMING_CONVENTION"/>
     <Class name="org.apache.spark.ShuffleType"/>
   </Match>
+  <Match>
+    <!-- Synthetic accessor inherited from Spark 4's Logging trait. -->
+    <Bug pattern="NM_METHOD_NAMING_CONVENTION"/>
+    <Method name="LogStringContext"/>
+  </Match>
 </FindBugsFilter>


### PR DESCRIPTION
### What changes were proposed in this pull request?

- Use Java 17 for Spotless, Checkstyle, Apache RAT, and SpotBugs jobs.
- Ensure these checks also cover the Spark 4.x profiles.
- Apply the required Spotless formatting to Spark 4 source files.

### Why are the changes needed?

The reusable sequential workflow only runs Spark 4.x profiles when using Java 17. Previously, these code quality checks used the default Java 8 configuration, so Spark 4.x modules were not covered.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?
