### PR TITLE
[#2783] fix(spark): correct compression ratio and failure counters in Spark UI

### DIFF
--- a/client-spark/extension/src/main/scala/org/apache/spark/UniffleStatusStore.scala
+++ b/client-spark/extension/src/main/scala/org/apache/spark/UniffleStatusStore.scala
@@ -242,8 +242,8 @@ object ShuffleType extends Enumeration {
 
 case class ShuffleTaskSummary(shuffleType: ShuffleType.Value,
                               var failureReasons: mutable.HashSet[String] = new mutable.HashSet[String](),
-                              var failedTaskNumber: Long = -1,
-                              var failedTaskMaxAttemptNumber: Long = -1) {
+                              var failedTaskNumber: Long = 0,
+                              var failedTaskMaxAttemptNumber: Long = 0) {
   @JsonIgnore
   @KVIndex
   def id: String = s"${classOf[ShuffleTaskSummary].getName}_${shuffleType.toString}"

--- a/client-spark/extension/src/main/scala/org/apache/spark/ui/ShufflePage.scala
+++ b/client-spark/extension/src/main/scala/org/apache/spark/ui/ShufflePage.scala
@@ -120,8 +120,8 @@ class ShufflePage(parent: ShuffleTab) extends WebUIPage("") with Logging {
       }
     }
     // compression ratio
-    val compressionRatio = if (taskInfo.shuffleBytes == 0) 0 else {
-      taskInfo.uncompressedShuffleBytes / taskInfo.shuffleBytes
+    val compressionRatio = if (taskInfo.shuffleBytes == 0) 0.0 else {
+      taskInfo.uncompressedShuffleBytes.toDouble / taskInfo.shuffleBytes
     }
 
     // speed unit is MB/sec


### PR DESCRIPTION
### What changes were proposed in this pull request?

- Calculate the Spark UI compression ratio using floating-point division.
  - Return `0.0` when the compressed shuffle size is zero.
  - Convert `uncompressedShuffleBytes` to `Double` before division.
- Initialize `failedTaskNumber` and `failedTaskMaxAttemptNumber` to `0` instead of `-1`.

### Why are the changes needed?

The compression ratio was calculated by dividing two `Long` values, so Scala performed integer division and discarded the fractional part.

For example, `150 / 100` was calculated as `1` and displayed as `1.0` instead of the expected `1.5`.

Additionally, initializing the failure count to `-1` caused the first failure to increment the count to `0`, resulting in an incorrect failure summary. Starting the failure-related fields at `0` correctly represents the initial state and counts the first failure.

Fix: #2783

### Does this PR introduce _any_ user-facing change?

Yes.

- Spark UI now displays fractional compression ratios correctly.
- Shuffle failure counters start at zero and include the first failure.

### How was this patch tested?
