### PR TITLE
[#2786] improvement(client): Avoid repeated cleanup scans in DecompressionWorker

### DIFF
--- a/client/src/main/java/org/apache/uniffle/client/impl/DecompressionWorker.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/DecompressionWorker.java
@@ -60,6 +60,10 @@ public class DecompressionWorker {
 
   private final Optional<Semaphore> segmentPermits;
 
+  // Only accessed by the single consumer, which fetches batches and segments in order.
+  private int nextBatchToClean = 0;
+  private int nextSegmentToClean = 0;
+
   public DecompressionWorker(
       Codec codec, int threads, int fetchSecondsThreshold, int maxConcurrentDecompressionSegments) {
     if (codec == null) {
@@ -156,11 +160,13 @@ public class DecompressionWorker {
   public DecompressedShuffleBlock get(int batchIndex, int segmentIndex) {
     // guardedly safe to remove the previous batches if exist since the upstream will fetch the
     // segments in order
-    for (int i = 0; i < batchIndex; i++) {
-      ConcurrentHashMap<Integer, DecompressedShuffleBlock> prevBlocks = tasks.remove(i);
+    while (nextBatchToClean < batchIndex) {
+      ConcurrentHashMap<Integer, DecompressedShuffleBlock> prevBlocks =
+          tasks.remove(nextBatchToClean++);
       if (prevBlocks != null) {
         segmentPermits.ifPresent(x -> x.release(prevBlocks.values().size()));
       }
+      nextSegmentToClean = 0;
     }
 
     ConcurrentHashMap<Integer, DecompressedShuffleBlock> blocks = tasks.get(batchIndex);
@@ -170,13 +176,14 @@ public class DecompressionWorker {
 
     // guardedly safe to remove the previous segments if exist since the upstream will fetch the
     // segments in order
-    for (int i = 0; i < segmentIndex; i++) {
-      if (blocks.remove(i) != null) {
+    while (nextSegmentToClean < segmentIndex) {
+      if (blocks.remove(nextSegmentToClean++) != null) {
         segmentPermits.ifPresent(x -> x.release());
       }
     }
 
     DecompressedShuffleBlock block = blocks.remove(segmentIndex);
+    nextSegmentToClean = Math.max(nextSegmentToClean, segmentIndex + 1);
     // simplify the memory statistic logic here, just decrease the memory used when the block is
     // fetched, this is effective due to the upstream will use single-thread to get and release the
     // block

--- a/client/src/test/java/org/apache/uniffle/client/impl/DecompressionWorkerTest.java
+++ b/client/src/test/java/org/apache/uniffle/client/impl/DecompressionWorkerTest.java
@@ -124,39 +124,4 @@ public class DecompressionWorkerTest {
     DecompressedShuffleBlock block1 = worker.get(0, 1);
     assertEquals(100, block1.getByteBuffer().remaining());
   }
-
-  @Test
-  public void testGetPerformance() {
-    RssConf rssConf = new RssConf();
-    rssConf.set(COMPRESSION_TYPE, Codec.Type.NOOP);
-    Codec codec = Codec.newInstance(rssConf).get();
-    // Warm up with a small batch before measuring 100,000 blocks.
-    for (int segmentCount : new int[] {1000, 100_000}) {
-      DecompressionWorker worker = new DecompressionWorker(codec, 1, 10, segmentCount);
-      try {
-        worker.add(0, createShuffleDataResult(segmentCount, codec, 1));
-        // Finish decompression before timing get(), so setup and decompression are excluded.
-        Awaitility.await()
-            .atMost(10, TimeUnit.SECONDS)
-            .until(() -> worker.getPeekMemoryUsed() == segmentCount);
-
-        int consumed = 0;
-        long start = System.nanoTime();
-        for (int segment = 0; segment < segmentCount; segment++) {
-          if (worker.get(0, segment) != null) {
-            consumed++;
-          }
-        }
-        long elapsed = System.nanoTime() - start;
-        assertEquals(segmentCount, consumed);
-        assertEquals(segmentCount, worker.getAvailablePermits());
-        // Report timing only; a fixed time limit would depend on JIT/GC and machine load.
-        System.out.printf(
-            "DecompressionWorker.get: blocks=%d, elapsed=%.3f ms%n",
-            segmentCount, elapsed / 1_000_000.0);
-      } finally {
-        worker.close();
-      }
-    }
-  }
 }

--- a/client/src/test/java/org/apache/uniffle/client/impl/DecompressionWorkerTest.java
+++ b/client/src/test/java/org/apache/uniffle/client/impl/DecompressionWorkerTest.java
@@ -124,4 +124,39 @@ public class DecompressionWorkerTest {
     DecompressedShuffleBlock block1 = worker.get(0, 1);
     assertEquals(100, block1.getByteBuffer().remaining());
   }
+
+  @Test
+  public void testGetPerformance() {
+    RssConf rssConf = new RssConf();
+    rssConf.set(COMPRESSION_TYPE, Codec.Type.NOOP);
+    Codec codec = Codec.newInstance(rssConf).get();
+    // Warm up with a small batch before measuring 100,000 blocks.
+    for (int segmentCount : new int[] {1000, 100_000}) {
+      DecompressionWorker worker = new DecompressionWorker(codec, 1, 10, segmentCount);
+      try {
+        worker.add(0, createShuffleDataResult(segmentCount, codec, 1));
+        // Finish decompression before timing get(), so setup and decompression are excluded.
+        Awaitility.await()
+            .atMost(10, TimeUnit.SECONDS)
+            .until(() -> worker.getPeekMemoryUsed() == segmentCount);
+
+        int consumed = 0;
+        long start = System.nanoTime();
+        for (int segment = 0; segment < segmentCount; segment++) {
+          if (worker.get(0, segment) != null) {
+            consumed++;
+          }
+        }
+        long elapsed = System.nanoTime() - start;
+        assertEquals(segmentCount, consumed);
+        assertEquals(segmentCount, worker.getAvailablePermits());
+        // Report timing only; a fixed time limit would depend on JIT/GC and machine load.
+        System.out.printf(
+            "DecompressionWorker.get: blocks=%d, elapsed=%.3f ms%n",
+            segmentCount, elapsed / 1_000_000.0);
+      } finally {
+        worker.close();
+      }
+    }
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

`DecompressionWorker.get()` scans all previous batch and segment indices on every block read, even after their entries have been removed. Sequentially consuming a batch of N blocks therefore performs `N(N−1)/2` redundant segment removals.

This PR tracks batch and segment cleanup progress so that subsequent reads only clean newly skipped indices. The segment cursor resets when advancing to another batch, preserving skipped-block cleanup and permit release behavior.

### Why are the changes needed?

Repeated cleanup causes quadratic overhead when overlapping decompression is enabled and a reader processes many blocks or batches. Tracking cleanup progress makes total cleanup work linear for sequential consumption.

closes #2786

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- Added a test covering skipped segments, batch transitions, and permit release.
- All 6 tests in `DecompressionWorkerTest` passed.
- Compared `org.apache.uniffle.client.impl.DecompressionWorkerTest#testGetPerformance` with and without the fix. The test waits for decompression to finish before timing sequential `get()` calls.

Without the fix:

```text
DecompressionWorker.get: blocks=1000, elapsed=5.381 ms
DecompressionWorker.get: blocks=100000, elapsed=13470.841 ms
```

With the fix:

```text
DecompressionWorker.get: blocks=1000, elapsed=1.139 ms
DecompressionWorker.get: blocks=100000, elapsed=8.458 ms
```

For 100,000 blocks, retrieval time decreased from approximately **13.47 seconds to 8.46 milliseconds** in this local test.
