### PR TITLE
[#2788] improvement(spark): Reduce the default Spark driver gRPC thread pool size to 64

### DIFF
--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/RssSparkConfig.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/RssSparkConfig.java
@@ -40,6 +40,12 @@ import org.apache.uniffle.common.config.RssConf;
 
 public class RssSparkConfig {
 
+  public static final ConfigOption<Integer> RSS_CLIENT_RPC_EXECUTOR_SIZE =
+      ConfigOptions.key("rss.clinet.rpc.executor.size")
+          .intType()
+          .defaultValue(64)
+          .withDescription("Core thread count for the shuffle manager gRPC server on the driver.");
+
   public static final ConfigOption<Boolean> RSS_CLIENT_INTEGRITY_VALIDATION_ENABLED =
       ConfigOptions.key("rss.client.integrityValidation.enabled")
           .booleanType()

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/RssSparkConfig.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/RssSparkConfig.java
@@ -41,7 +41,7 @@ import org.apache.uniffle.common.config.RssConf;
 public class RssSparkConfig {
 
   public static final ConfigOption<Integer> RSS_CLIENT_RPC_EXECUTOR_SIZE =
-      ConfigOptions.key("rss.clinet.rpc.executor.size")
+      ConfigOptions.key("rss.client.rpc.executor.size")
           .intType()
           .defaultValue(64)
           .withDescription("Core thread count for the shuffle manager gRPC server on the driver.");

--- a/client-spark/common/src/main/java/org/apache/uniffle/shuffle/manager/ShuffleManagerServerFactory.java
+++ b/client-spark/common/src/main/java/org/apache/uniffle/shuffle/manager/ShuffleManagerServerFactory.java
@@ -49,10 +49,10 @@ public class ShuffleManagerServerFactory {
       if (service == null) {
         service = new ShuffleManagerGrpcService(shuffleManager);
       }
-      conf.set(
-          RssBaseConf.RPC_EXECUTOR_SIZE, conf.get(RssSparkConfig.RSS_CLIENT_RPC_EXECUTOR_SIZE));
+      int poolSize = conf.get(RssSparkConfig.RSS_CLIENT_RPC_EXECUTOR_SIZE);
       return GrpcServer.Builder.newBuilder()
           .conf(conf)
+          .threadPoolSize(poolSize)
           .grpcMetrics(GRPCMetrics.getEmptyGRPCMetrics(conf))
           .addService(service)
           .build();

--- a/client-spark/common/src/main/java/org/apache/uniffle/shuffle/manager/ShuffleManagerServerFactory.java
+++ b/client-spark/common/src/main/java/org/apache/uniffle/shuffle/manager/ShuffleManagerServerFactory.java
@@ -17,6 +17,8 @@
 
 package org.apache.uniffle.shuffle.manager;
 
+import org.apache.spark.shuffle.RssSparkConfig;
+
 import org.apache.uniffle.common.config.RssBaseConf;
 import org.apache.uniffle.common.config.RssConf;
 import org.apache.uniffle.common.metrics.GRPCMetrics;
@@ -47,6 +49,8 @@ public class ShuffleManagerServerFactory {
       if (service == null) {
         service = new ShuffleManagerGrpcService(shuffleManager);
       }
+      conf.set(
+          RssBaseConf.RPC_EXECUTOR_SIZE, conf.get(RssSparkConfig.RSS_CLIENT_RPC_EXECUTOR_SIZE));
       return GrpcServer.Builder.newBuilder()
           .conf(conf)
           .grpcMetrics(GRPCMetrics.getEmptyGRPCMetrics(conf))

--- a/common/src/main/java/org/apache/uniffle/common/rpc/GrpcServer.java
+++ b/common/src/main/java/org/apache/uniffle/common/rpc/GrpcServer.java
@@ -24,6 +24,7 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
@@ -66,12 +67,24 @@ public class GrpcServer implements ServerInterface {
       RssBaseConf conf,
       List<Pair<BindableService, List<ServerInterceptor>>> servicesWithInterceptors,
       GRPCMetrics grpcMetrics) {
+    this(conf, servicesWithInterceptors, grpcMetrics, null);
+  }
+
+  private GrpcServer(
+      RssBaseConf conf,
+      List<Pair<BindableService, List<ServerInterceptor>>> servicesWithInterceptors,
+      GRPCMetrics grpcMetrics,
+      Integer threadPoolSize) {
     this.rssConf = conf;
     this.configuredPort = rssConf.getInteger(RssBaseConf.RPC_SERVER_PORT);
     this.servicesWithInterceptors = servicesWithInterceptors;
     this.grpcMetrics = grpcMetrics;
 
-    int rpcExecutorSize = conf.getInteger(RssBaseConf.RPC_EXECUTOR_SIZE);
+    Supplier<Integer> rpcExecutorSizeSupplier =
+        threadPoolSize == null
+            ? () -> conf.getInteger(RssBaseConf.RPC_EXECUTOR_SIZE)
+            : () -> threadPoolSize;
+    int rpcExecutorSize = rpcExecutorSizeSupplier.get();
     int queueSize = conf.getInteger(RssBaseConf.RPC_EXECUTOR_QUEUE_SIZE);
     pool =
         new GrpcThreadPoolExecutor(
@@ -84,8 +97,8 @@ public class GrpcServer implements ServerInterface {
             grpcMetrics);
     ThreadPoolManager.registerThreadPool(
         "Grpc",
-        () -> conf.getInteger(RssBaseConf.RPC_EXECUTOR_SIZE),
-        () -> conf.getInteger(RssBaseConf.RPC_EXECUTOR_SIZE) * 2,
+        rpcExecutorSizeSupplier,
+        () -> rpcExecutorSizeSupplier.get() * 2,
         () -> TimeUnit.MINUTES.toMillis(10),
         pool);
   }
@@ -141,6 +154,7 @@ public class GrpcServer implements ServerInterface {
 
     private RssBaseConf rssBaseConf;
     private GRPCMetrics grpcMetrics;
+    private Integer threadPoolSize;
 
     private List<Pair<BindableService, List<ServerInterceptor>>> servicesWithInterceptors =
         new ArrayList<>();
@@ -151,6 +165,12 @@ public class GrpcServer implements ServerInterface {
 
     public Builder conf(RssBaseConf rssBaseConf) {
       this.rssBaseConf = rssBaseConf;
+      return this;
+    }
+
+    /** Sets a fixed core thread count instead of using {@link RssBaseConf#RPC_EXECUTOR_SIZE}. */
+    public Builder threadPoolSize(int threadPoolSize) {
+      this.threadPoolSize = threadPoolSize;
       return this;
     }
 
@@ -165,7 +185,7 @@ public class GrpcServer implements ServerInterface {
     }
 
     public GrpcServer build() {
-      return new GrpcServer(rssBaseConf, servicesWithInterceptors, grpcMetrics);
+      return new GrpcServer(rssBaseConf, servicesWithInterceptors, grpcMetrics, threadPoolSize);
     }
   }
 

--- a/common/src/main/java/org/apache/uniffle/common/rpc/GrpcServer.java
+++ b/common/src/main/java/org/apache/uniffle/common/rpc/GrpcServer.java
@@ -24,7 +24,6 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.Supplier;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
@@ -80,11 +79,8 @@ public class GrpcServer implements ServerInterface {
     this.servicesWithInterceptors = servicesWithInterceptors;
     this.grpcMetrics = grpcMetrics;
 
-    Supplier<Integer> rpcExecutorSizeSupplier =
-        threadPoolSize == null
-            ? () -> conf.getInteger(RssBaseConf.RPC_EXECUTOR_SIZE)
-            : () -> threadPoolSize;
-    int rpcExecutorSize = rpcExecutorSizeSupplier.get();
+    int rpcExecutorSize =
+        threadPoolSize == null ? conf.getInteger(RssBaseConf.RPC_EXECUTOR_SIZE) : threadPoolSize;
     int queueSize = conf.getInteger(RssBaseConf.RPC_EXECUTOR_QUEUE_SIZE);
     pool =
         new GrpcThreadPoolExecutor(
@@ -97,8 +93,8 @@ public class GrpcServer implements ServerInterface {
             grpcMetrics);
     ThreadPoolManager.registerThreadPool(
         "Grpc",
-        rpcExecutorSizeSupplier,
-        () -> rpcExecutorSizeSupplier.get() * 2,
+        () -> rpcExecutorSize,
+        () -> rpcExecutorSize * 2,
         () -> TimeUnit.MINUTES.toMillis(10),
         pool);
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add `spark.rss.client.rpc.executor.size` with a default of 64. 

### Why are the changes needed?

The ShuffleManager currently inherits a default core pool size of 1000. These threads remain alive when idle, causing unnecessary native memory overhead, including thread stacks. A dedicated setting reduces the default footprint and allows independent tuning.

closes #2788

### Does this PR introduce any user-facing change?

Yes. Adds `spark.rss.clinet.rpc.executor.size` with a default of 64 to control the driver-side ShuffleManager gRPC core thread pool size, reducing its default from 1000 to 64. This setting takes precedence over `spark.rss.rpc.executor.size` for that server. Remote Shuffle Server configuration remains unchanged.

### How was this patch tested?
<!--
(Please test your changes, and provide instructions on how to test it:
  1. If you add a feature or fix a bug, add a test to cover your changes. 
  2. If you fix a flaky test, repeat it for many times to prove it works.)
-->
